### PR TITLE
Adds an option to disable the vampire hud

### DIFF
--- a/src/main/java/de/teamlapen/vampirism/client/gui/VampirismHUDOverlay.java
+++ b/src/main/java/de/teamlapen/vampirism/client/gui/VampirismHUDOverlay.java
@@ -209,7 +209,7 @@ public class VampirismHUDOverlay extends ExtendedGui {
 
     @SubscribeEvent(priority = EventPriority.LOW)
     public void onRenderWorldLast(RenderWorldLastEvent event) {
-        if (screenPercentage > 0) {
+        if (screenPercentage > 0 && !Configs.disable_vampire_overlay) {
             //Set the working matrix/layer to a layer directly on the screen/in front of the player
             ScaledResolution scaledresolution = new ScaledResolution(this.mc);
             // int factor=scaledresolution.getScaleFactor();

--- a/src/main/java/de/teamlapen/vampirism/config/Configs.java
+++ b/src/main/java/de/teamlapen/vampirism/config/Configs.java
@@ -53,6 +53,7 @@ public class Configs {
     public static boolean updated_vampirism;
     public static boolean disable_vampireEyes;
     public static boolean disable_config_sync;
+    public static boolean disable_vampire_overlay;
 
     public static boolean autoConvertGlasBottles;
     private static Configuration main_config;
@@ -161,6 +162,7 @@ public class Configs {
         disable_advancedMobPlayerFaces = main_config.getBoolean("disable_advanced_mob_player_face", CATEGORY_DISABLE, false, "Disable the rendering of other player faces for the advanced hunter and advanced vampire");
         disable_vampireEyes = main_config.getBoolean("disable_vampire_player_eyes", CATEGORY_DISABLE, false, "Disables the rendering of vampire eyes");
         disable_config_sync = main_config.getBoolean("disable_config_sync", CATEGORY_DISABLE, false, "Disable syncing config between server and client. (Note: Only a few settings are synced anyway)");
+        disable_vampire_overlay = main_config.getBoolean("disable_hud_overlay", CATEGORY_DISABLE, false, "disable HUD overlay if they cause problems.");
 
         updated_vampirism = !main_config.getDefinedConfigVersion().equals(main_config.getLoadedConfigVersion());
 


### PR DESCRIPTION
This adds an config file entry to disable the vampire hud. The hud
causes severe graphics errors, when shaders are used. While this doesn't
fix it, it provides a workaround.