### PR TITLE
Another IMob attempt

### DIFF
--- a/src/api/java/de/teamlapen/vampirism/api/entity/factions/IFaction.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/factions/IFaction.java
@@ -56,4 +56,9 @@ public interface IFaction<T extends IFactionEntity> {
      * @return The same instance
      */
     IFaction<T> setTranslationKeys(String name, String plural);
+
+    /**
+     * @return Whether entities of this faction are hostile towards neutral entities
+     */
+    boolean isHostileTowardsNeutral();
 }

--- a/src/api/java/de/teamlapen/vampirism/api/entity/factions/IFactionRegistry.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/factions/IFactionRegistry.java
@@ -74,7 +74,7 @@ public interface IFactionRegistry {
      * @return The created faction
      */
     @ThreadSafeAPI
-    <T extends IFactionEntity> IFaction registerFaction(ResourceLocation id, Class<T> entityInterface, int color);
+    <T extends IFactionEntity> IFaction registerFaction(ResourceLocation id, Class<T> entityInterface, int color, boolean hostileTowardsNeutral);
 
     /**
      * Create and registerAdvancements a playable faction. Has to be called during InterModEnqueueEvent
@@ -88,5 +88,5 @@ public interface IFactionRegistry {
      * @return The created faction
      */
     @ThreadSafeAPI
-    <T extends IFactionPlayer> IPlayableFaction registerPlayableFaction(ResourceLocation id, Class<T> entityInterface, int color, NonNullSupplier<Capability<T>> playerCapabilitySupplier, int highestLevel);
+    <T extends IFactionPlayer> IPlayableFaction registerPlayableFaction(ResourceLocation id, Class<T> entityInterface, int color, boolean hostileTowardsNeutral, NonNullSupplier<Capability<T>> playerCapabilitySupplier, int highestLevel);
 }

--- a/src/api/java/de/teamlapen/vampirism/api/entity/vampire/IVampireBaron.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/vampire/IVampireBaron.java
@@ -2,9 +2,10 @@ package de.teamlapen.vampirism.api.entity.vampire;
 
 import de.teamlapen.vampirism.api.difficulty.IAdjustableLevel;
 import de.teamlapen.vampirism.api.entity.minions.IMinionLordWithSaveable;
+import net.minecraft.entity.monster.IMob;
 
 /**
  * Vampire that spawns in the vampire forest, has minions and drops pure blood
  */
-public interface IVampireBaron extends IVampireMob, IMinionLordWithSaveable<IVampireMinion.Saveable>, IAdjustableLevel {
+public interface IVampireBaron extends IVampireMob, IMinionLordWithSaveable<IVampireMinion.Saveable>, IAdjustableLevel, IMob {
 }

--- a/src/main/java/de/teamlapen/vampirism/VampirismMod.java
+++ b/src/main/java/de/teamlapen/vampirism/VampirismMod.java
@@ -307,9 +307,10 @@ public class VampirismMod {
      * Setup API during pre-init before configs are loaded
      */
     private void setupAPI2() {
-        VReference.VAMPIRE_FACTION = VampirismAPI.factionRegistry().registerPlayableFaction(REFERENCE.VAMPIRE_PLAYER_KEY, IVampirePlayer.class, 0XFF780DA3, () -> VampirePlayer.CAP, REFERENCE.HIGHEST_VAMPIRE_LEVEL);
+        //TODO add faction entity interface
+        VReference.VAMPIRE_FACTION = VampirismAPI.factionRegistry().registerPlayableFaction(REFERENCE.VAMPIRE_PLAYER_KEY, IVampirePlayer.class, 0XFF780DA3, true, () -> VampirePlayer.CAP, REFERENCE.HIGHEST_VAMPIRE_LEVEL);
         VReference.VAMPIRE_FACTION.setChatColor(TextFormatting.DARK_PURPLE).setTranslationKeys("text.vampirism.vampire", "text.vampirism.vampires");
-        VReference.HUNTER_FACTION = VampirismAPI.factionRegistry().registerPlayableFaction(REFERENCE.HUNTER_PLAYER_KEY, IHunterPlayer.class, Color.BLUE.getRGB(), () -> HunterPlayer.CAP, REFERENCE.HIGHEST_HUNTER_LEVEL);
+        VReference.HUNTER_FACTION = VampirismAPI.factionRegistry().registerPlayableFaction(REFERENCE.HUNTER_PLAYER_KEY, IHunterPlayer.class, Color.BLUE.getRGB(), false, () -> HunterPlayer.CAP, REFERENCE.HIGHEST_HUNTER_LEVEL);
         VReference.HUNTER_FACTION.setChatColor(TextFormatting.DARK_BLUE).setTranslationKeys("text.vampirism.hunter", "text.vampirism.hunters");
         VReference.HUNTER_CREATURE_TYPE = HUNTER_CREATURE_TYPE;
         VReference.VAMPIRE_CREATURE_TYPE = VAMPIRE_CREATURE_TYPE;

--- a/src/main/java/de/teamlapen/vampirism/config/VampirismConfig.java
+++ b/src/main/java/de/teamlapen/vampirism/config/VampirismConfig.java
@@ -101,6 +101,8 @@ public class VampirismConfig {
         public final ForgeConfigSpec.BooleanValue autoConvertGlassBottles;
         public final ForgeConfigSpec.BooleanValue playerCanTurnPlayer;
         public final ForgeConfigSpec.BooleanValue factionColorInChat;
+        public final ForgeConfigSpec.EnumValue<IMobOptions> entityIMob;
+
 
         public final ForgeConfigSpec.BooleanValue sundamageUnknownDimension;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> sundamageDimensionsOverridePositive;
@@ -131,6 +133,7 @@ public class VampirismConfig {
             autoConvertGlassBottles = builder.comment("Whether glass bottles should be automatically be converted to blood bottles when needed").define("autoConvertGlassBottles", true);
             playerCanTurnPlayer = builder.comment("Whether players can infect other players").define("playersCanTurnPlayers", true);
             factionColorInChat = builder.comment("Whether to color player names in chat based on their current faction").define("factionColorInChat", true);
+            entityIMob = builder.comment("Changes if entities are recognized as hostile by other mods. See https://github.com/TeamLapen/Vampirism/issues/199. Smart falls back to Never on servers ").defineEnum("entitiesIMob", IMobOptions.SMART);
 
 
             builder.push("sundamage");
@@ -189,6 +192,10 @@ public class VampirismConfig {
             builder.pop();
 
             builder.pop();
+        }
+
+        public enum IMobOptions {
+            ALWAYS_IMOB, NEVER_IMOB, SMART
         }
     }
 
@@ -249,8 +256,8 @@ public class VampirismConfig {
             versionCheck = builder.comment("Check for new versions of Vampirism on startup").define("versionCheck", true);
             collectStats = builder.comment("Send mod version, MC version and mod count to mod author").define("collectStats", true);
             disableVampireForest = builder.comment("Disable vampire forest generation").define("disableVampireForest", false);
-
             builder.pop();
         }
+
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/core/ModEntities.java
+++ b/src/main/java/de/teamlapen/vampirism/core/ModEntities.java
@@ -2,7 +2,6 @@ package de.teamlapen.vampirism.core;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-
 import de.teamlapen.vampirism.api.VReference;
 import de.teamlapen.vampirism.api.VampirismAPI;
 import de.teamlapen.vampirism.api.entity.IVampirismEntityRegistry;
@@ -47,11 +46,14 @@ public class ModEntities {
 
     public static final EntityType<BlindingBatEntity> blinding_bat = prepareEntityType("blinding_bat", EntityType.Builder.create(BlindingBatEntity::new, EntityClassification.MISC).size(0.5F, 0.9F), true);
     public static final EntityType<GhostEntity> ghost = prepareEntityType("ghost", EntityType.Builder.create(GhostEntity::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.8F, 1.95F), true);
-    public static final EntityType<ConvertedCreatureEntity> converted_creature = prepareEntityType("converted_creature", EntityType.Builder.<ConvertedCreatureEntity>create(ConvertedCreatureEntity::new, EntityClassification.CREATURE), false);
+    public static final EntityType<ConvertedCreatureEntity> converted_creature = prepareEntityType("converted_creature", EntityType.Builder.create(ConvertedCreatureEntity::new, EntityClassification.CREATURE), false);
+    public static final EntityType<ConvertedCreatureEntity.IMob> converted_creature_imob = prepareEntityType("converted_creature_imob", EntityType.Builder.create(ConvertedCreatureEntity.IMob::new, EntityClassification.CREATURE), false);
     public static final EntityType<ConvertedSheepEntity> converted_sheep = prepareEntityType("converted_sheep", EntityType.Builder.create(ConvertedSheepEntity::new, EntityClassification.CREATURE).size(0.9F, 1.3F), false);
     public static final EntityType<BasicHunterEntity> vampire_hunter = prepareEntityType("vampire_hunter", EntityType.Builder.create(BasicHunterEntity::new, VReference.HUNTER_CREATURE_TYPE).size(0.6F, 1.95F), true);
+    public static final EntityType<BasicHunterEntity.IMob> vampire_hunter_imob = prepareEntityType("vampire_hunter_imob", EntityType.Builder.create(BasicHunterEntity.IMob::new, VReference.HUNTER_CREATURE_TYPE).size(0.6f, 1.95f), false);
     public static final EntityType<HunterTrainerEntity> hunter_trainer = prepareEntityType("hunter_trainer", EntityType.Builder.create(HunterTrainerEntity::new, VReference.HUNTER_CREATURE_TYPE).size(0.6F, 1.95F), true);
     public static final EntityType<AdvancedHunterEntity> advanced_hunter = prepareEntityType("advanced_hunter", EntityType.Builder.create(AdvancedHunterEntity::new, VReference.HUNTER_CREATURE_TYPE).size(0.6F, 1.95F), true);
+    public static final EntityType<AdvancedHunterEntity.IMob> advanced_hunter_imob = prepareEntityType("advanced_hunter_imob", EntityType.Builder.create(AdvancedHunterEntity.IMob::new, VReference.HUNTER_CREATURE_TYPE).size(0.6f, 1.95f), false);
     public static final EntityType<VampireBaronEntity> vampire_baron = prepareEntityType("vampire_baron", EntityType.Builder.create(VampireBaronEntity::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.6F, 1.95F), true);
     public static final EntityType<VampireMinionSaveableEntity> vampire_minion_s = prepareEntityType("vampire_minion_s", EntityType.Builder.create(VampireMinionSaveableEntity::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.5F, 1.1F), false);
     public static final EntityType<DummyBittenAnimalEntity> dummy_creature = prepareEntityType("dummy_creature", EntityType.Builder.create(DummyBittenAnimalEntity::new, EntityClassification.CREATURE), false);
@@ -67,7 +69,9 @@ public class ModEntities {
     public static final EntityType<VampireFactionVillagerEntity> villager_vampire_faction = prepareEntityType("villager_vampire_faction", EntityType.Builder.create(VampireFactionVillagerEntity::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.6F, 1.95F), true);
     public static final EntityType<DummyHunterTrainerEntity> hunter_trainer_dummy = prepareEntityType("hunter_trainer_dummy", EntityType.Builder.create(DummyHunterTrainerEntity::new, EntityClassification.MISC).size(0.6F, 1.95F), true);
     public static final EntityType<BasicVampireEntity> vampire = prepareEntityType("vampire", EntityType.Builder.create(BasicVampireEntity::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.6F, 1.95F), true);
+    public static final EntityType<BasicVampireEntity.IMob> vampire_imob = prepareEntityType("vampire_imob", EntityType.Builder.create(BasicVampireEntity.IMob::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.6f, 1.95f), false);
     public static final EntityType<AdvancedVampireEntity> advanced_vampire = prepareEntityType("advanced_vampire", EntityType.Builder.create(AdvancedVampireEntity::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.6F, 1.95F), true);
+    public static final EntityType<AdvancedVampireEntity.IMob> advanced_vampire_imob = prepareEntityType("advanced_vampire_imob", EntityType.Builder.create(AdvancedVampireEntity.IMob::new, VReference.VAMPIRE_CREATURE_TYPE).size(0.6f, 1.95f), false);
 
     public static final VillagerProfession hunter_expert = getNull();
     public static final VillagerProfession vampire_expert = getNull();
@@ -105,10 +109,13 @@ public class ModEntities {
         registry.register(blinding_bat);
         registry.register(ghost);
         registry.register(converted_creature);
+        registry.register(converted_creature_imob);
         registry.register(converted_sheep);
         registry.register(vampire_hunter);
+        registry.register(vampire_hunter_imob);
         registry.register(hunter_trainer);
         registry.register(advanced_hunter);
+        registry.register(advanced_hunter_imob);
         registry.register(vampire_baron);
         registry.register(vampire_minion_s);
         registry.register(dummy_creature);
@@ -124,7 +131,9 @@ public class ModEntities {
         registry.register(villager_vampire_faction);
         registry.register(hunter_trainer_dummy);
         registry.register(vampire);
+        registry.register(vampire_imob);
         registry.register(advanced_vampire);
+        registry.register(advanced_vampire_imob);
         //add to biomes
         for (Biome e : getZombieBiomes()) {
             e.getSpawns(VReference.VAMPIRE_CREATURE_TYPE).add(new Biome.SpawnListEntry(vampire, Balance.mobProps.VAMPIRE_SPAWN_CHANCE, 1, 2));

--- a/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedCreatureEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedCreatureEntity.java
@@ -6,6 +6,7 @@ import de.teamlapen.vampirism.api.VampirismAPI;
 import de.teamlapen.vampirism.api.entity.convertible.IConvertedCreature;
 import de.teamlapen.vampirism.api.entity.convertible.IConvertingHandler;
 import de.teamlapen.vampirism.core.ModBlocks;
+import de.teamlapen.vampirism.core.ModEntities;
 import de.teamlapen.vampirism.entity.goals.AttackMeleeNoSunGoal;
 import de.teamlapen.vampirism.entity.vampire.VampireBaseEntity;
 import net.minecraft.block.Blocks;
@@ -37,14 +38,19 @@ public class ConvertedCreatureEntity<T extends CreatureEntity> extends VampireBa
     private boolean entityChanged = false;
     private boolean canDespawn = false;
 
-    public ConvertedCreatureEntity(EntityType<? extends CreatureEntity> type, World world) {
+    public ConvertedCreatureEntity(EntityType<? extends ConvertedCreatureEntity> type, World world) {
         super(type, world, false);
-
+        this.enableImobConversion();
     }
 
     @Override
     public ITextComponent getName() {
         return new StringTextComponent(new TranslationTextComponent("entity.vampirism.vampire.name") + " " + (nil() ? super.getName() : entityCreature.getName()));
+    }
+
+    @Override
+    protected EntityType<?> getIMobTypeOpt(boolean iMob) {
+        return iMob ? ModEntities.converted_creature_imob : ModEntities.converted_creature;
     }
 
     public T getOldCreature() {
@@ -267,5 +273,12 @@ public class ConvertedCreatureEntity<T extends CreatureEntity> extends VampireBa
 
     public static boolean spawnPredicate(EntityType<? extends ConvertedCreatureEntity> entityType, IWorld iWorld, SpawnReason spawnReason, BlockPos blockPos, Random random) {
         return (iWorld.getBlockState(blockPos.down()).getBlock() == Blocks.GRASS_BLOCK || iWorld.getBlockState(blockPos.down()).getBlock() == ModBlocks.cursed_earth) && iWorld.getLightSubtracted(blockPos, 0) > 8;
+    }
+
+    public static class IMob extends ConvertedCreatureEntity implements net.minecraft.entity.monster.IMob {
+
+        public IMob(EntityType<? extends ConvertedCreatureEntity> type, World world) {
+            super(type, world);
+        }
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/factions/Faction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/factions/Faction.java
@@ -23,16 +23,20 @@ public class Faction<T extends IFactionEntity> implements IFaction<T> {
     private String translationKey;
     @Nullable
     private String translationKeyPlural;
+
+    private final boolean hostileTowardsNeutral;
+
     /**
      * Id used for hashing
      */
     private int integerId;
     private TextFormatting chatColor;
 
-    Faction(ResourceLocation id, Class<T> entityInterface, int color) {
+    Faction(ResourceLocation id, Class<T> entityInterface, int color, boolean hostileTowardsNeutral) {
         this.id = id;
         this.entityInterface = entityInterface;
         this.color = color;
+        this.hostileTowardsNeutral = hostileTowardsNeutral;
         integerId = nextId++;
     }
 
@@ -99,5 +103,10 @@ public class Faction<T extends IFactionEntity> implements IFaction<T> {
                 "id='" + integerId + '\'' +
                 ", hash=" + integerId +
                 '}';
+    }
+
+    @Override
+    public boolean isHostileTowardsNeutral() {
+        return hostileTowardsNeutral;
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/factions/FactionRegistry.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/factions/FactionRegistry.java
@@ -130,22 +130,22 @@ public class FactionRegistry implements IFactionRegistry {
     }
 
     @Override
-    public <T extends IFactionEntity> IFaction registerFaction(ResourceLocation id, Class<T> entityInterface, int color) {
+    public <T extends IFactionEntity> IFaction registerFaction(ResourceLocation id, Class<T> entityInterface, int color, boolean hostileTowardsNeutral) {
         if (!UtilLib.isNonNull(id, entityInterface)) {
             throw new IllegalArgumentException("[Vampirism]Parameter for faction cannot be null");
         }
-        Faction<T> f = new Faction<>(id, entityInterface, color);
+        Faction<T> f = new Faction<>(id, entityInterface, color, hostileTowardsNeutral);
         addFaction(f);
         return f;
     }
 
     @Override
-    public <T extends IFactionPlayer> IPlayableFaction registerPlayableFaction(ResourceLocation id, Class<T> entityInterface, int color, NonNullSupplier<Capability<T>> playerCapabilitySupplier, int highestLevel) {
+    public <T extends IFactionPlayer> IPlayableFaction registerPlayableFaction(ResourceLocation id, Class<T> entityInterface, int color, boolean hostileTowardsNeutral, NonNullSupplier<Capability<T>> playerCapabilitySupplier, int highestLevel) {
         if (!UtilLib.isNonNull(id, entityInterface, playerCapabilitySupplier)) {
             throw new IllegalArgumentException("[Vampirism]Parameters for faction cannot be null");
         }
 
-        PlayableFaction<T> f = new PlayableFaction<>(id, entityInterface, color, playerCapabilitySupplier, highestLevel);
+        PlayableFaction<T> f = new PlayableFaction<>(id, entityInterface, color, hostileTowardsNeutral, playerCapabilitySupplier, highestLevel);
         addFaction(f);
         return f;
     }

--- a/src/main/java/de/teamlapen/vampirism/entity/factions/PlayableFaction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/factions/PlayableFaction.java
@@ -16,8 +16,8 @@ public class PlayableFaction<T extends IFactionPlayer> extends Faction<T> implem
     private final NonNullSupplier<Capability<T>> playerCapabilitySupplier;
     private boolean renderLevel = true;
 
-    PlayableFaction(ResourceLocation id, Class<T> entityInterface, int color, NonNullSupplier<Capability<T>> playerCapabilitySupplier, int highestLevel) {
-        super(id, entityInterface, color);
+    PlayableFaction(ResourceLocation id, Class<T> entityInterface, int color, boolean hostileTowardsNeutral, NonNullSupplier<Capability<T>> playerCapabilitySupplier, int highestLevel) {
+        super(id, entityInterface, color, hostileTowardsNeutral);
         this.highestLevel = highestLevel;
         this.playerCapabilitySupplier = playerCapabilitySupplier;
     }

--- a/src/main/java/de/teamlapen/vampirism/entity/hunter/AdvancedHunterEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/hunter/AdvancedHunterEntity.java
@@ -7,6 +7,7 @@ import de.teamlapen.vampirism.api.entity.actions.EntityActionTier;
 import de.teamlapen.vampirism.api.entity.actions.IEntityActionUser;
 import de.teamlapen.vampirism.api.entity.hunter.IAdvancedHunter;
 import de.teamlapen.vampirism.config.Balance;
+import de.teamlapen.vampirism.core.ModEntities;
 import de.teamlapen.vampirism.entity.action.ActionHandlerEntity;
 import de.teamlapen.vampirism.entity.vampire.VampireBaseEntity;
 import de.teamlapen.vampirism.util.IPlayerFace;
@@ -63,6 +64,7 @@ public class AdvancedHunterEntity extends HunterBaseEntity implements IAdvancedH
         entityclass = EntityClassType.getRandomClass(this.getRNG());
         IEntityActionUser.applyAttributes(this);
         this.entityActionHandler = new ActionHandlerEntity<>(this);
+        this.enableImobConversion();
     }
 
     @Override
@@ -72,6 +74,11 @@ public class AdvancedHunterEntity extends HunterBaseEntity implements IAdvancedH
             this.swingArm(Hand.MAIN_HAND);  //Swing stake if nothing else is held
         }
         return flag;
+    }
+
+    @Override
+    protected EntityType<?> getIMobTypeOpt(boolean iMob) {
+        return iMob ? ModEntities.advanced_hunter_imob : ModEntities.advanced_hunter;
     }
 
     @Override
@@ -251,4 +258,10 @@ public class AdvancedHunterEntity extends HunterBaseEntity implements IAdvancedH
         return entitytier;
     }
 
+    public static class IMob extends AdvancedHunterEntity implements net.minecraft.entity.monster.IMob {
+
+        public IMob(EntityType<? extends AdvancedHunterEntity> type, World world) {
+            super(type, world);
+        }
+    }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/hunter/BasicHunterEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/hunter/BasicHunterEntity.java
@@ -8,6 +8,7 @@ import de.teamlapen.vampirism.api.entity.actions.EntityActionTier;
 import de.teamlapen.vampirism.api.entity.actions.IEntityActionUser;
 import de.teamlapen.vampirism.api.entity.hunter.IBasicHunter;
 import de.teamlapen.vampirism.config.Balance;
+import de.teamlapen.vampirism.core.ModEntities;
 import de.teamlapen.vampirism.core.ModItems;
 import de.teamlapen.vampirism.entity.action.ActionHandlerEntity;
 import de.teamlapen.vampirism.entity.goals.AttackRangedCrossbowGoal;
@@ -116,6 +117,7 @@ public class BasicHunterEntity extends HunterBaseEntity implements IBasicHunter,
         entityclass = EntityClassType.getRandomClass(this.getRNG());
         IEntityActionUser.applyAttributes(this);
         this.entityActionHandler = new ActionHandlerEntity<>(this);
+        this.enableImobConversion();
     }
 
     @Override
@@ -125,6 +127,11 @@ public class BasicHunterEntity extends HunterBaseEntity implements IBasicHunter,
             this.swingArm(Hand.MAIN_HAND);  //Swing stake if nothing else is held
         }
         return flag;
+    }
+
+    @Override
+    protected EntityType<?> getIMobTypeOpt(boolean iMob) {
+        return iMob ? ModEntities.vampire_hunter_imob : ModEntities.vampire_hunter;
     }
 
     @Override
@@ -489,5 +496,11 @@ public class BasicHunterEntity extends HunterBaseEntity implements IBasicHunter,
         return entitytier;
     }
 
+    public static class IMob extends BasicHunterEntity implements net.minecraft.entity.monster.IMob {
+
+        public IMob(EntityType<? extends BasicHunterEntity> type, World world) {
+            super(type, world);
+        }
+    }
 
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/special/DraculaHalloweenEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/special/DraculaHalloweenEntity.java
@@ -2,7 +2,6 @@ package de.teamlapen.vampirism.entity.special;
 
 
 import de.teamlapen.lib.lib.util.UtilLib;
-import de.teamlapen.vampirism.VampirismMod;
 import de.teamlapen.vampirism.core.ModEntities;
 import de.teamlapen.vampirism.core.ModSounds;
 import de.teamlapen.vampirism.entity.AreaParticleCloudEntity;
@@ -97,7 +96,7 @@ public class DraculaHalloweenEntity extends VampirismEntity {
         }
         if (this.world.isRemote) {
             LivingEntity owner = getOwner();
-            if (owner != null && !isInvisible() && !VampirismMod.proxy.isPlayerThePlayer((PlayerEntity) owner)) {
+            if (owner != null && !isInvisible() && !((PlayerEntity) owner).isUser()) {
                 this.setInvisible(true);
                 LOGGER.info("Setting invisible on other client");
             }

--- a/src/main/java/de/teamlapen/vampirism/entity/vampire/AdvancedVampireEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/vampire/AdvancedVampireEntity.java
@@ -8,6 +8,7 @@ import de.teamlapen.vampirism.api.entity.actions.IEntityActionUser;
 import de.teamlapen.vampirism.api.entity.vampire.IAdvancedVampire;
 import de.teamlapen.vampirism.config.Balance;
 import de.teamlapen.vampirism.core.ModEffects;
+import de.teamlapen.vampirism.core.ModEntities;
 import de.teamlapen.vampirism.entity.action.ActionHandlerEntity;
 import de.teamlapen.vampirism.entity.goals.AttackMeleeNoSunGoal;
 import de.teamlapen.vampirism.entity.goals.FleeGarlicVampireGoal;
@@ -67,6 +68,12 @@ public class AdvancedVampireEntity extends VampireBaseEntity implements IAdvance
         entityclass = EntityClassType.getRandomClass(this.getRNG());
         IEntityActionUser.applyAttributes(this);
         this.entityActionHandler = new ActionHandlerEntity<>(this);
+        this.enableImobConversion();
+    }
+
+    @Override
+    protected EntityType<?> getIMobTypeOpt(boolean iMob) {
+        return iMob ? ModEntities.advanced_vampire_imob : ModEntities.advanced_vampire;
     }
 
     @Override
@@ -271,4 +278,10 @@ public class AdvancedVampireEntity extends VampireBaseEntity implements IAdvance
     }
 
 
+    public static class IMob extends AdvancedVampireEntity implements net.minecraft.entity.monster.IMob {
+
+        public IMob(EntityType<? extends AdvancedVampireEntity> type, World world) {
+            super(type, world);
+        }
+    }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/vampire/BasicVampireEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/vampire/BasicVampireEntity.java
@@ -12,6 +12,7 @@ import de.teamlapen.vampirism.api.entity.factions.IFactionEntity;
 import de.teamlapen.vampirism.api.entity.vampire.IBasicVampire;
 import de.teamlapen.vampirism.config.Balance;
 import de.teamlapen.vampirism.core.ModEffects;
+import de.teamlapen.vampirism.core.ModEntities;
 import de.teamlapen.vampirism.core.ModSounds;
 import de.teamlapen.vampirism.entity.action.ActionHandlerEntity;
 import de.teamlapen.vampirism.entity.goals.*;
@@ -102,9 +103,15 @@ public class BasicVampireEntity extends VampireBaseEntity implements IBasicVampi
         entityclass = EntityClassType.getRandomClass(this.getRNG());
         IEntityActionUser.applyAttributes(this);
         this.entityActionHandler = new ActionHandlerEntity<>(this);
+        this.enableImobConversion();
     }
 
-//    @Nullable
+    @Override
+    protected EntityType<?> getIMobTypeOpt(boolean iMob) {
+        return iMob ? ModEntities.vampire_imob : ModEntities.vampire;
+    }
+
+    //    @Nullable
 //    @Override
 //    public IVampirismVillage getCurrentFriendlyVillage() {
 //        return cachedVillage != null ? cachedVillage.getControllingFaction() == VReference.VAMPIRE_FACTION ? cachedVillage : null : null;
@@ -390,5 +397,12 @@ public class BasicVampireEntity extends VampireBaseEntity implements IBasicVampi
     @Override
     public List<IEntityAction> getAvailableActions() {
         return VampirismAPI.entityActionManager().getAllEntityActionsByTierAndClassType(((IFactionEntity) this).getFaction(), entitytier, entityclass);
+    }
+
+    public static class IMob extends BasicVampireEntity implements net.minecraft.entity.monster.IMob {
+
+        public IMob(EntityType<? extends BasicVampireEntity> type, World world) {
+            super(type, world);
+        }
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/proxy/ClientProxy.java
+++ b/src/main/java/de/teamlapen/vampirism/proxy/ClientProxy.java
@@ -55,10 +55,7 @@ public class ClientProxy extends CommonProxy {
         return Minecraft.getInstance().getRenderPartialTicks();
     }
 
-    @Override
-    public boolean isClientPlayerNull() {
-        return Minecraft.getInstance().player == null;
-    }
+
 
     @Override
     public SkillTree getSkillTree(boolean client) {
@@ -70,9 +67,10 @@ public class ClientProxy extends CommonProxy {
         if (overlay != null) overlay.makeRenderFullColor(ticksOn, ticksOff, color);
     }
 
+    @Nullable
     @Override
-    public boolean isPlayerThePlayer(PlayerEntity player) {
-        return Minecraft.getInstance().player.equals(player);
+    public PlayerEntity getClientPlayer() {
+        return Minecraft.getInstance().player;
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/proxy/CommonProxy.java
+++ b/src/main/java/de/teamlapen/vampirism/proxy/CommonProxy.java
@@ -17,6 +17,7 @@ public abstract class CommonProxy implements IProxy {
     public void onInitStep(Step step, ModLifecycleEvent event) {
     }
 
+
     @Override
     public SkillTree getSkillTree(boolean client) {
         return SkillTreeManager.getInstance().getSkillTree();

--- a/src/main/java/de/teamlapen/vampirism/proxy/IProxy.java
+++ b/src/main/java/de/teamlapen/vampirism/proxy/IProxy.java
@@ -17,16 +17,8 @@ public interface IProxy extends IInitListener {
         return 1F;
     }
 
-    boolean isClientPlayerNull();
-
-    /**
-     * Probably just check {@link PlayerEntity#isUser()}
-     *
-     * @param player
-     * @return
-     */
-    @Deprecated
-    boolean isPlayerThePlayer(PlayerEntity player);
+    @Nullable
+    PlayerEntity getClientPlayer();
 
     void renderScreenFullColor(int ticksOn, int ticksOff, int color);
 

--- a/src/main/java/de/teamlapen/vampirism/proxy/ServerProxy.java
+++ b/src/main/java/de/teamlapen/vampirism/proxy/ServerProxy.java
@@ -11,16 +11,11 @@ import javax.annotation.Nullable;
 public class ServerProxy extends CommonProxy {
 
 
+    @Nullable
     @Override
-    public boolean isClientPlayerNull() {
-        return false;
+    public PlayerEntity getClientPlayer() {
+        return null;
     }
-
-    @Override
-    public boolean isPlayerThePlayer(PlayerEntity player) {
-        return false;
-    }
-
 
     @Override
     public void renderScreenFullColor(int ticksOn, int ticksOff, int color) {


### PR DESCRIPTION
With 1.14 some things got easier to implement, so let's give it another try. #48 #190 #199 #492

This PR adds IMob variants for the relevant mobs (this means subclass and new entity type).
There are three configuration options:
- Always IMob
- Smart
- Never IMob (equivalent to the previous state)

Still, only the non IMob type is spawned, but if required the entity replaces itself with the IMob version. Unfortunately, this requires them to get a new UUID, but everything else should remain unchanged.

The Smart option deducts the "target" variant from the faction of the Singleplayer player. On dedicated servers, this falls back to never IMob.

The system seems to work fine, but I have no idea what further issues might occur.
It will most likely also not help with issues like special torches not preventing vampires from spawning, as only the non IMob version is spawned.


### Alternative
An alternative which is much more elegant, but only allows a static IMob/nonIMob configuration would be to not introduce new entity types but make the standard entity type factory create the according instance. 
Much cleaner, but static. If there should be any issues with the other variant, we will fall back to this.
