### PR TITLE
use LazyOptionals /w Optionals for CaptureEntities and TotemTileEntity

### DIFF
--- a/src/api/java/de/teamlapen/vampirism/api/entity/IVillageCaptureEntity.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/IVillageCaptureEntity.java
@@ -3,8 +3,11 @@ package de.teamlapen.vampirism.api.entity;
 import de.teamlapen.vampirism.api.entity.factions.IFactionEntity;
 import de.teamlapen.vampirism.api.world.IVillageAttributes;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.common.util.LazyOptional;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 
 /**
@@ -14,12 +17,6 @@ public interface IVillageCaptureEntity extends IFactionEntity {
     void attackVillage(IVillageAttributes totem);
 
     void defendVillage(IVillageAttributes totem);
-
-    /**
-     * @return The village area that is target of the capture
-     */
-    @Nullable
-    AxisAlignedBB getTargetVillageArea();
 
     boolean isAttackingVillage();
 
@@ -34,7 +31,7 @@ public interface IVillageCaptureEntity extends IFactionEntity {
     /**
      * @return A (cached) instance of the village the entity is currently in if it is of the same faction or null otherwise
      */
-    @Nullable
-    IVillageAttributes getVillageAttributes();
+    @Nonnull
+    LazyOptional<Optional<IVillageAttributes>> getVillageAttributes();
 
 }

--- a/src/api/java/de/teamlapen/vampirism/api/world/IVillageAttributes.java
+++ b/src/api/java/de/teamlapen/vampirism/api/world/IVillageAttributes.java
@@ -3,7 +3,9 @@ package de.teamlapen.vampirism.api.world;
 import de.teamlapen.vampirism.api.entity.factions.IFaction;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.util.LazyOptional;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface IVillageAttributes {
@@ -14,6 +16,7 @@ public interface IVillageAttributes {
     @Nullable
     IFaction getAttackingFaction();
 
+    @Nonnull
     AxisAlignedBB getVillageArea();
 
     BlockPos getPosition();

--- a/src/lib/java/de/teamlapen/lib/lib/util/UtilLib.java
+++ b/src/lib/java/de/teamlapen/lib/lib/util/UtilLib.java
@@ -36,6 +36,7 @@ import net.minecraft.world.gen.Heightmap;
 import net.minecraft.world.spawner.WorldEntitySpawner;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.apache.logging.log4j.LogManager;
@@ -211,6 +212,19 @@ public class UtilLib {
         double x = p.posX + sinYaw * distance;
         double z = p.posZ + cosYaw * distance;
         return new BlockPos(x, p.posY, z);
+    }
+
+    /**
+     * @param world           World
+     * @param box             LazyOptional of the Area where the creature should spawn
+     * @param e               Entity that has a EntityType<? extends EntityLiving>
+     * @param maxTry          Max position tried
+     * @param avoidedEntities Avoid being to close or seen by these entities. If no valid spawn location is found, this is ignored
+     * @param reason          Spawn reason
+     * @return Successful spawn
+     */
+    public static boolean spawnEntityInWorld(World world, LazyOptional<AxisAlignedBB> box, Entity e, int maxTry, @Nonnull List<? extends LivingEntity> avoidedEntities, SpawnReason reason) {
+        return box.map(box2 -> spawnEntityInWorld(world, box2, e, maxTry, avoidedEntities, reason)).orElse(false);
     }
 
     /**

--- a/src/main/java/de/teamlapen/vampirism/entity/goals/AttackVillageGoal.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/goals/AttackVillageGoal.java
@@ -2,15 +2,19 @@ package de.teamlapen.vampirism.entity.goals;
 
 import de.teamlapen.vampirism.api.VampirismAPI;
 import de.teamlapen.vampirism.api.entity.IVillageCaptureEntity;
+import de.teamlapen.vampirism.api.world.IVillageAttributes;
 import de.teamlapen.vampirism.entity.VampirismEntity;
 import net.minecraft.entity.EntityPredicate;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.goal.TargetGoal;
+import net.minecraft.util.math.AxisAlignedBB;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 
 public class AttackVillageGoal<T extends VampirismEntity & IVillageCaptureEntity> extends TargetGoal {
+    private static final AxisAlignedBB NULLAXIS = new AxisAlignedBB(0,0,0,0,0,0);
 
     private final T attacker;
     private EntityPredicate entityPredicate;
@@ -21,13 +25,13 @@ public class AttackVillageGoal<T extends VampirismEntity & IVillageCaptureEntity
         this.attacker = creature;
         this.entityPredicate = new EntityPredicate() {
             @Override
-            public boolean canTarget(@Nullable LivingEntity p_221015_1_, LivingEntity p_221015_2_) {
-                if (attacker.getVillageAttributes().shouldForceTargets() && getTargetDistance() > 0) {
+            public boolean canTarget(@Nullable LivingEntity entity, @Nonnull LivingEntity entity1) {
+                if (attacker.getVillageAttributes().map(opt -> opt.map(IVillageAttributes::shouldForceTargets).orElse(false)).orElse(false) && getTargetDistance() > 0) {
                     setDistance(-1.0D);
                 } else if (getTargetDistance() < 0) {
                     setDistance(distance);
                 }
-                return super.canTarget(p_221015_1_, p_221015_2_);
+                return super.canTarget(entity, entity1);
             }
         }.setCustomPredicate(VampirismAPI.factionRegistry().getPredicate(attacker.getFaction(), false));
     }
@@ -35,7 +39,7 @@ public class AttackVillageGoal<T extends VampirismEntity & IVillageCaptureEntity
     @Override
     public boolean shouldExecute() {
         if (!attacker.isAttackingVillage()) return false;
-        this.target = this.attacker.world.getClosestEntityWithinAABB(LivingEntity.class, entityPredicate, this.goalOwner, this.goalOwner.posX, this.goalOwner.posY + (double) this.goalOwner.getEyeHeight(), this.goalOwner.posZ, attacker.getTargetVillageArea());
+        this.target = this.attacker.world.getClosestEntityWithinAABB(LivingEntity.class, entityPredicate, this.goalOwner, this.goalOwner.posX, this.goalOwner.posY + (double) this.goalOwner.getEyeHeight(), this.goalOwner.posZ, this.attacker.getVillageAttributes().map(opt -> opt.map(IVillageAttributes::getVillageArea).orElse(NULLAXIS)).orElse(NULLAXIS));
         return target != null;
     }
 

--- a/src/main/java/de/teamlapen/vampirism/entity/goals/DefendVillageGoal.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/goals/DefendVillageGoal.java
@@ -2,15 +2,20 @@ package de.teamlapen.vampirism.entity.goals;
 
 import de.teamlapen.vampirism.api.VampirismAPI;
 import de.teamlapen.vampirism.api.entity.IVillageCaptureEntity;
+import de.teamlapen.vampirism.api.world.IVillageAttributes;
 import net.minecraft.entity.CreatureEntity;
 import net.minecraft.entity.EntityPredicate;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.goal.TargetGoal;
+import net.minecraft.util.math.AxisAlignedBB;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 
 public class DefendVillageGoal<T extends CreatureEntity & IVillageCaptureEntity> extends TargetGoal {
+    private static final AxisAlignedBB NULLAXIS = new AxisAlignedBB(0,0,0,0,0,0);
+
 
     private T creature;
     private EntityPredicate entityPredicate;
@@ -21,13 +26,13 @@ public class DefendVillageGoal<T extends CreatureEntity & IVillageCaptureEntity>
         this.creature = creature;
         this.entityPredicate = new EntityPredicate() {
             @Override
-            public boolean canTarget(@Nullable LivingEntity p_221015_1_, LivingEntity p_221015_2_) {
-                if (creature.getVillageAttributes().shouldForceTargets() && getTargetDistance() > 0) {
+            public boolean canTarget(@Nullable LivingEntity entity, @Nonnull LivingEntity entity1) {
+                if (creature.getVillageAttributes().map(opt -> opt.map(IVillageAttributes::shouldForceTargets).orElse(false)).orElse(false) && getTargetDistance() > 0) {
                     setDistance(-1.0D);
                 } else if (getTargetDistance() < 0) {
                     setDistance(distance);
                 }
-                return super.canTarget(p_221015_1_, p_221015_2_);
+                return super.canTarget(entity, entity1);
             }
         }.setCustomPredicate(VampirismAPI.factionRegistry().getPredicate(creature.getFaction(), false));
     }
@@ -35,7 +40,7 @@ public class DefendVillageGoal<T extends CreatureEntity & IVillageCaptureEntity>
     @Override
     public boolean shouldExecute() {
         if (!creature.isDefendingVillage()) return false;
-        this.target = this.creature.world.getClosestEntityWithinAABB(LivingEntity.class, entityPredicate, this.goalOwner, this.goalOwner.posX, this.goalOwner.posY + (double) this.goalOwner.getEyeHeight(), this.goalOwner.posZ, creature.getTargetVillageArea());
+        this.target = this.creature.world.getClosestEntityWithinAABB(LivingEntity.class, entityPredicate, this.goalOwner, this.goalOwner.posX, this.goalOwner.posY + (double) this.goalOwner.getEyeHeight(), this.goalOwner.posZ, creature.getVillageAttributes().map(opt -> opt.map(IVillageAttributes::getVillageArea).orElse(NULLAXIS)).orElse(NULLAXIS));
         return target != null;
     }
 

--- a/src/main/java/de/teamlapen/vampirism/entity/hunter/AdvancedHunterEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/hunter/AdvancedHunterEntity.java
@@ -320,22 +320,23 @@ public class AdvancedHunterEntity extends HunterBaseEntity implements IAdvancedH
 
     //Village capture --------------------------------------------------------------------------------------------------
     private boolean attack;
-    private LazyOptional<Optional<IVillageAttributes>> villageAttributes;
+    @Nonnull
+    private LazyOptional<Optional<IVillageAttributes>> villageAttributes = LazyOptional.empty();
 
     @Override
     public void stopVillageAttackDefense() {
         this.setCustomName(null);
-        this.villageAttributes = null;
+        this.villageAttributes = LazyOptional.empty();
     }
 
     @Override
     public boolean isAttackingVillage() {
-        return villageAttributes != null && attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && attack;
     }
 
     @Override
     public boolean isDefendingVillage() {
-        return villageAttributes.isPresent() && !attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && !attack;
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/entity/hunter/AggressiveVillagerEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/hunter/AggressiveVillagerEntity.java
@@ -29,9 +29,11 @@ import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.LazyOptional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * Villager that is equipped with a fork and hunts vampires
@@ -64,7 +66,7 @@ public class AggressiveVillagerEntity extends VampirismVillagerEntity implements
     }
 
     @Override
-    public ILivingEntityData onInitialSpawn(IWorld worldIn, DifficultyInstance difficultyIn, SpawnReason reason, @Nullable ILivingEntityData spawnDataIn, @Nullable CompoundNBT dataTag) {
+    public ILivingEntityData onInitialSpawn(@Nonnull IWorld worldIn, @Nonnull DifficultyInstance difficultyIn, @Nonnull SpawnReason reason, @Nullable ILivingEntityData spawnDataIn, @Nullable CompoundNBT dataTag) {
         ILivingEntityData data = super.onInitialSpawn(worldIn, difficultyIn, reason, spawnDataIn, dataTag);
         this.setItemStackToSlot(EquipmentSlotType.MAINHAND, new ItemStack(ModItems.pitchfork));
         return data;
@@ -105,7 +107,7 @@ public class AggressiveVillagerEntity extends VampirismVillagerEntity implements
     }
 
     //Village capture---------------------------------------------------------------------------------------------------
-    private IVillageAttributes villageAttributes;
+    private LazyOptional<Optional<IVillageAttributes>> villageAttributes = LazyOptional.empty();
     @Override
     public void stopVillageAttackDefense() {
         VillagerEntity villager = EntityType.VILLAGER.create(this.world);
@@ -130,22 +132,18 @@ public class AggressiveVillagerEntity extends VampirismVillagerEntity implements
 
     @Override
     public void attackVillage(IVillageAttributes villageAttributes) {
-        this.villageAttributes = villageAttributes;
+        this.villageAttributes = LazyOptional.of(() -> Optional.of(villageAttributes));
     }
 
     @Override
     public void defendVillage(IVillageAttributes villageAttributes) {
-        this.villageAttributes = villageAttributes;
+        this.villageAttributes = LazyOptional.of(() -> Optional.of(villageAttributes));
     }
 
-    @Nullable
+    @Nonnull
     @Override
-    public IVillageAttributes getVillageAttributes() {
+    public LazyOptional<Optional<IVillageAttributes>> getVillageAttributes() {
         return villageAttributes;
     }
 
-    @Override
-    public AxisAlignedBB getTargetVillageArea() {
-        return villageAttributes.getVillageArea();
-    }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/hunter/AggressiveVillagerEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/hunter/AggressiveVillagerEntity.java
@@ -107,6 +107,7 @@ public class AggressiveVillagerEntity extends VampirismVillagerEntity implements
     }
 
     //Village capture---------------------------------------------------------------------------------------------------
+    @Nonnull
     private LazyOptional<Optional<IVillageAttributes>> villageAttributes = LazyOptional.empty();
     @Override
     public void stopVillageAttackDefense() {
@@ -127,7 +128,7 @@ public class AggressiveVillagerEntity extends VampirismVillagerEntity implements
 
     @Override
     public boolean isDefendingVillage() {
-        return villageAttributes != null;
+        return villageAttributes.map(Optional::isPresent).orElse(false);
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/entity/hunter/BasicHunterEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/hunter/BasicHunterEntity.java
@@ -456,22 +456,23 @@ public class BasicHunterEntity extends HunterBaseEntity implements IBasicHunter,
 
     //Village capture --------------------------------------------------------------------------------------------------
     private boolean attack;
-    private LazyOptional<Optional<IVillageAttributes>> villageAttributes;
+    @Nonnull
+    private LazyOptional<Optional<IVillageAttributes>> villageAttributes = LazyOptional.empty();
 
     @Override
     public void stopVillageAttackDefense() {
         this.setCustomName(null);
-        this.villageAttributes = null;
+        this.villageAttributes = LazyOptional.empty();
     }
 
     @Override
     public boolean isAttackingVillage() {
-        return villageAttributes != null && attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && attack;
     }
 
     @Override
     public boolean isDefendingVillage() {
-        return villageAttributes != null && !attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && !attack;
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/entity/vampire/AdvancedVampireEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/vampire/AdvancedVampireEntity.java
@@ -332,6 +332,7 @@ public class AdvancedVampireEntity extends VampireBaseEntity implements IAdvance
     }
 
     //Village stuff ----------------------------------------------------------------------------------------------------
+    @Nonnull
     private LazyOptional<Optional<IVillageAttributes>> villageAttributes = LazyOptional.empty();
     private boolean attack;
 
@@ -356,16 +357,16 @@ public class AdvancedVampireEntity extends VampireBaseEntity implements IAdvance
     @Override
     public void stopVillageAttackDefense() {
         this.setCustomName(null);
-        this.villageAttributes = null;
+        this.villageAttributes = LazyOptional.empty();
     }
 
     @Override
     public boolean isAttackingVillage() {
-        return villageAttributes.isPresent() && attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && attack;
     }
 
     @Override
     public boolean isDefendingVillage() {
-        return villageAttributes.isPresent() && !attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && !attack;
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/vampire/BasicVampireEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/vampire/BasicVampireEntity.java
@@ -343,6 +343,7 @@ public class BasicVampireEntity extends VampireBaseEntity implements IBasicVampi
     }
 
     //Village stuff ----------------------------------------------------------------------------------------------------
+    @Nonnull
     private LazyOptional<Optional<IVillageAttributes>> villageAttributes = LazyOptional.empty();
     private boolean attack;
 
@@ -374,11 +375,11 @@ public class BasicVampireEntity extends VampireBaseEntity implements IBasicVampi
 
     @Override
     public boolean isAttackingVillage() {
-        return villageAttributes.isPresent() && attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && attack;
     }
 
     @Override
     public boolean isDefendingVillage() {
-        return villageAttributes.isPresent() && !attack;
+        return villageAttributes.map(Optional::isPresent).orElse(false) && !attack;
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/tileentity/TotemTileEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/tileentity/TotemTileEntity.java
@@ -61,6 +61,7 @@ import net.minecraft.world.gen.feature.structure.Structures;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -153,8 +154,9 @@ public class TotemTileEntity extends TileEntity implements ITickableTileEntity {
         return new TranslationTextComponent("command.vampirism.test.village.success", faction.getName());
     }
 
-    public static VillageAttributes getVillageAttributes(TotemTileEntity totem) {
-        return new VillageAttributes(totem);
+    @Nullable
+    public static VillageAttributes getVillageAttributes(@Nullable TotemTileEntity totem) {
+        return totem == null ? null :new VillageAttributes(totem);
     }
 
     //block attributes
@@ -622,14 +624,14 @@ public class TotemTileEntity extends TileEntity implements ITickableTileEntity {
         this.progressColor = faction != null ? faction.getColor().getColorComponents(null) : DyeColor.WHITE.getColorComponentValues();
     }
 
-    public @Nonnull
-    AxisAlignedBB getVillageArea() {
-        return this.villageArea == null ? this.villageArea = AxisAlignedBB.func_216363_a(this.village.getBoundingBox()) : this.villageArea;
+    @Nonnull
+    public AxisAlignedBB getVillageArea() {
+        return this.villageArea == null ? this.village != null ?this.villageArea = AxisAlignedBB.func_216363_a(this.village.getBoundingBox()) :new AxisAlignedBB(0,0,0,0,0,0): this.villageArea;
     }
 
-    private @Nonnull
-    AxisAlignedBB getVillageAreaReduced() {
-        return this.villageAreaReduced == null ? this.villageAreaReduced = AxisAlignedBB.func_216363_a(this.village.getBoundingBox()).grow(-30, -10, -30) : this.villageAreaReduced;
+    @Nonnull
+    private AxisAlignedBB getVillageAreaReduced() {
+        return this.villageAreaReduced == null ? this.village != null ?this.villageAreaReduced = AxisAlignedBB.func_216363_a(this.village.getBoundingBox()).grow(-30, -10, -30) : new AxisAlignedBB(0,0,0,0,0,0): this.villageAreaReduced;
     }
 
     public void initiateCapture(PlayerEntity player) {
@@ -976,6 +978,7 @@ public class TotemTileEntity extends TileEntity implements ITickableTileEntity {
             return this.attackingFaction;
         }
 
+        @Nonnull
         @Override
         public AxisAlignedBB getVillageArea() {
             return this.villageArea;


### PR DESCRIPTION
Replace the hard reference of the TotemTileEntity in CaptureEntities with LazyOptionals
 (@maxanier forge/vanilla solves the LazyOptionals null problematic with LazyOptionals of Optionals)
#629