### PR TITLE
[1.14/1.15] Totems consider only PointOfInterest instead of Structures

### DIFF
--- a/src/lib/java/de/teamlapen/lib/lib/util/UtilLib.java
+++ b/src/lib/java/de/teamlapen/lib/lib/util/UtilLib.java
@@ -706,6 +706,10 @@ public class UtilLib {
         return new MutableBoundingBox(array[0], array[1], array[2], array[3], array[4], array[5]);
     }
 
+    public static MutableBoundingBox AABBtoMB(AxisAlignedBB bb) {
+        return new MutableBoundingBox((int)bb.minX,(int)bb.minY,(int)bb.minZ,(int)bb.maxX,(int)bb.maxY,(int)bb.maxZ);
+    }
+
     public enum RotationAmount {
         NINETY,
         HUNDRED_EIGHTY,

--- a/src/main/java/de/teamlapen/vampirism/core/ModVillage.java
+++ b/src/main/java/de/teamlapen/vampirism/core/ModVillage.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.teamlapen.vampirism.entity.villager.Trades;
 import de.teamlapen.vampirism.util.REFERENCE;
+import de.teamlapen.vampirism.world.FactionPointOfInterestType;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.entity.ai.brain.schedule.Activity;
 import net.minecraft.entity.ai.brain.schedule.Schedule;
@@ -26,8 +27,9 @@ public class ModVillage {
     public static final VillagerProfession hunter_expert = getNull();
     public static final VillagerProfession vampire_expert = getNull();
 
-    public static final PointOfInterestType hunter_faction = getNull();
-    public static final PointOfInterestType vampire_faction = getNull();
+    public static final FactionPointOfInterestType no_faction = getNull();
+    public static final FactionPointOfInterestType hunter_faction = getNull();
+    public static final FactionPointOfInterestType vampire_faction = getNull();
 
     public static final Schedule converted_default = getNull();
 
@@ -41,12 +43,15 @@ public class ModVillage {
     }
 
     static void registerVillagePointOfInterestType(IForgeRegistry<PointOfInterestType> registry) {
-        PointOfInterestType hunter_faction = new PointOfInterestType("hunter_faction", ImmutableSet.of(ModBlocks.totem_top_vampirism_hunter.getStateContainer().getBaseState()), 1, null, 1).setRegistryName(REFERENCE.MODID, "hunter_faction");
-        PointOfInterestType vampire_faction = new PointOfInterestType("vampire_faction", ImmutableSet.of(ModBlocks.totem_top_vampirism_vampire.getStateContainer().getBaseState()), 1, null, 1).setRegistryName(REFERENCE.MODID, "vampire_faction");
+        PointOfInterestType hunter_faction = new FactionPointOfInterestType("hunter_faction", ImmutableSet.of(ModBlocks.totem_top_vampirism_hunter.getStateContainer().getBaseState()), 1, null, 1).setRegistryName(REFERENCE.MODID, "hunter_faction");
+        PointOfInterestType vampire_faction = new FactionPointOfInterestType("vampire_faction", ImmutableSet.of(ModBlocks.totem_top_vampirism_vampire.getStateContainer().getBaseState()), 1, null, 1).setRegistryName(REFERENCE.MODID, "vampire_faction");
+        PointOfInterestType no_faction = new FactionPointOfInterestType("no_faction", ImmutableSet.of(ModBlocks.totem_top.getStateContainer().getBaseState()),1,null,1).setRegistryName(REFERENCE.MODID,"no_faction");
         registry.register(hunter_faction);
         registry.register(vampire_faction);
+        registry.register(no_faction);
         PointOfInterestType.func_221052_a(hunter_faction);
         PointOfInterestType.func_221052_a(vampire_faction);
+        PointOfInterestType.func_221052_a(no_faction);
     }
 
     static void registerSchedule(IForgeRegistry<Schedule> registry) {

--- a/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
@@ -41,8 +41,9 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.gen.feature.structure.StructureStart;
-import net.minecraft.world.gen.feature.structure.Structures;
+import net.minecraft.village.PointOfInterest;
+import net.minecraft.village.PointOfInterestManager;
+import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -56,6 +57,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.thread.EffectiveSide;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Event handler for all entity related events
@@ -237,16 +242,14 @@ public class ModEntityEventHandler {
             //------------------
 
             if (event.getEntity() instanceof VillagerEntity) {
-                if (Structures.VILLAGE.isPositionInStructure(event.getWorld(), event.getEntity().getPosition())) {
-                    StructureStart structure = Structures.VILLAGE.getStart(event.getWorld(), event.getEntity().getPosition(), false);
-                    if (!(structure == StructureStart.DUMMY)) {
-                        BlockPos pos = TotemTileEntity.getTotemPosition(structure);
-                        if (pos != null) {
-                            TileEntity tileEntity = event.getWorld().getTileEntity(pos);
-                            if (tileEntity instanceof TotemTileEntity) {
-                                if (VReference.HUNTER_FACTION.equals(((TotemTileEntity) tileEntity).getControllingFaction())) {
-                                    ExtendedCreature.getSafe(event.getEntity()).ifPresent(e -> e.setPoisonousBlood(true));
-                                }
+                Collection<PointOfInterest> points = ((ServerWorld) event.getWorld()).getPointOfInterestManager().func_219146_b(p -> true, event.getEntity().getPosition(), 25, PointOfInterestManager.Status.ANY).collect(Collectors.toList());
+                if (points.size()>0) {
+                    BlockPos pos = TotemTileEntity.getTotemPosition(points);
+                    if (pos != null) {
+                        TileEntity tileEntity = event.getWorld().getTileEntity(pos);
+                        if (tileEntity instanceof TotemTileEntity) {
+                            if (VReference.HUNTER_FACTION.equals(((TotemTileEntity) tileEntity).getControllingFaction())) {
+                                ExtendedCreature.getSafe(event.getEntity()).ifPresent(e -> e.setPoisonousBlood(true));
                             }
                         }
                     }

--- a/src/main/java/de/teamlapen/vampirism/entity/goals/GolemTargetVampireGoal.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/goals/GolemTargetVampireGoal.java
@@ -3,11 +3,19 @@ package de.teamlapen.vampirism.entity.goals;
 import de.teamlapen.vampirism.api.VReference;
 import de.teamlapen.vampirism.api.VampirismAPI;
 import de.teamlapen.vampirism.tileentity.TotemTileEntity;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.goal.NearestAttackableTargetGoal;
 import net.minecraft.entity.passive.IronGolemEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.village.PointOfInterest;
+import net.minecraft.village.PointOfInterestManager;
 import net.minecraft.world.gen.feature.structure.Structures;
+import net.minecraft.world.server.ServerWorld;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Targets vampires if the golem as a non vampire village assigned
@@ -23,8 +31,9 @@ public class GolemTargetVampireGoal extends NearestAttackableTargetGoal<LivingEn
 
     @Override
     public boolean shouldExecute() {
-        if (Structures.VILLAGE.isPositionInStructure(golem.world, golem.getPosition())) {
-            BlockPos pos = TotemTileEntity.getTotemPosition(Structures.VILLAGE.getStart(golem.world, golem.getPosition(), false));
+        Collection<PointOfInterest> points = ((ServerWorld)this.golem.world).getPointOfInterestManager().func_219146_b(p->true,this.golem.getPosition(),35, PointOfInterestManager.Status.ANY).collect(Collectors.toList());
+        if (points.size()>0) {
+            BlockPos pos = TotemTileEntity.getTotemPosition(points);
             if (pos != null) {
                 TotemTileEntity tile = ((TotemTileEntity) golem.world.getTileEntity(pos));
                 if (tile != null && VReference.VAMPIRE_FACTION.equals(tile.getControllingFaction())) {

--- a/src/main/java/de/teamlapen/vampirism/world/FactionPointOfInterestType.java
+++ b/src/main/java/de/teamlapen/vampirism/world/FactionPointOfInterestType.java
@@ -1,0 +1,19 @@
+package de.teamlapen.vampirism.world;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.village.PointOfInterestType;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public class FactionPointOfInterestType extends PointOfInterestType {
+    public FactionPointOfInterestType(String name, Set<BlockState> validStates, int maxFreeTickets, @Nullable SoundEvent workSound, Predicate<PointOfInterestType> p_i51553_5_, int p_i51553_6_) {
+        super(name, validStates, maxFreeTickets, workSound, p_i51553_5_, p_i51553_6_);
+    }
+
+    public FactionPointOfInterestType(String name, Set<BlockState> validStates, int maxFreeTickets, @Nullable SoundEvent workSound, int p_i51554_5_) {
+        super(name, validStates, maxFreeTickets, workSound, p_i51554_5_);
+    }
+}


### PR DESCRIPTION
transfoms the totems to only consider PointOfInterest for villages.

things to consider/existing issues:
  - destroyed PointOfInterests not removed from TotemTileEntity#vampireVillages
  - when should a collection of PointofInterests be considered a village
  - update BoundingBox if a PointofInterest has been added
  - when 2 villages collide update vampirevillage map
  - when 2 villages collide when one totem wins update the other entities

- remove https://github.com/Cheaterpaul/Vampirism/blob/f34347cb72bab9bb0c8e83af40aa16ebd53f10b8/src/main/java/de/teamlapen/vampirism/tileentity/TotemTileEntity.java#L184

close #694