### PR TITLE
Register structure separation during load.

### DIFF
--- a/src/main/java/de/teamlapen/vampirism/VampirismMod.java
+++ b/src/main/java/de/teamlapen/vampirism/VampirismMod.java
@@ -187,7 +187,6 @@ public class VampirismMod {
 
     @SubscribeEvent
     public void onServerAboutToStart(FMLServerAboutToStartEvent event) {
-        ModFeatures.registerStructureSeparation();
         ModWorld.addVillageStructures();
     }
 

--- a/src/main/java/de/teamlapen/vampirism/config/VampirismConfig.java
+++ b/src/main/java/de/teamlapen/vampirism/config/VampirismConfig.java
@@ -146,7 +146,6 @@ public class VampirismConfig {
 
         public final ForgeConfigSpec.IntValue villageDistance;
         public final ForgeConfigSpec.IntValue villageSeparation;
-        public final ForgeConfigSpec.BooleanValue villageModify;
 
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> blacklistedBloodEntity;
 
@@ -189,7 +188,6 @@ public class VampirismConfig {
             builder.pop();
 
             builder.push("village");
-            villageModify = builder.comment("Whether to modify the village world gen (size and frequency)").define("villageModify", true);
             villageDistance = builder.comment("Village distance").defineInRange("villageDistance", 32, 1, 100); //TODO 1.17 improve comment
             villageSeparation = builder.comment("Village centers will be at least N chunks apart. Must be smaller than distance").defineInRange("villageSeparation", 8, 1, 100);
             builder.pop();
@@ -283,7 +281,8 @@ public class VampirismConfig {
         public final ForgeConfigSpec.BooleanValue versionCheck;
         public final ForgeConfigSpec.BooleanValue collectStats;
         public final ForgeConfigSpec.ConfigValue<String> integrationsNotifier;
-        public final ForgeConfigSpec.BooleanValue useVanillaCampfire;
+        public final ForgeConfigSpec.BooleanValue useVanillaCampfire; //TODO 1.17 move to Server config
+        public final ForgeConfigSpec.BooleanValue villageModify;
 
 
         Common(ForgeConfigSpec.Builder builder) {
@@ -294,6 +293,8 @@ public class VampirismConfig {
             useVanillaCampfire = builder.comment("Use the vanilla campfire block instead of Vampirism's much cooler one").define("useVanillaCampfire", false);
 
             integrationsNotifier = builder.comment("INTERNAL - Set to 'never' if you don't want to be notified about integration mods").define("integrationsNotifier", "");
+            villageModify = builder.comment("Whether to modify the village world gen (size and frequency), based on world config").define("villageModify", true);
+
             builder.pop();
         }
 

--- a/src/main/java/de/teamlapen/vampirism/core/ModFeatures.java
+++ b/src/main/java/de/teamlapen/vampirism/core/ModFeatures.java
@@ -4,6 +4,7 @@ package de.teamlapen.vampirism.core;
 import com.google.common.collect.Lists;
 import de.teamlapen.vampirism.api.VampirismAPI;
 import de.teamlapen.vampirism.config.VampirismConfig;
+import de.teamlapen.vampirism.util.ConfigurableStructureSeparationSettings;
 import de.teamlapen.vampirism.util.REFERENCE;
 import de.teamlapen.vampirism.world.gen.features.ModLakeFeature;
 import de.teamlapen.vampirism.world.gen.features.VampireDungeonFeature;
@@ -65,15 +66,19 @@ public class ModFeatures {
 
     }
 
+
+    /**
+     * Not safe to run in parallel with other mods
+     */
     public static void registerStructureSeparation() {
         //https://github.com/MinecraftForge/MinecraftForge/pull/7232
         //https://github.com/MinecraftForge/MinecraftForge/pull/7331
         Map<Structure<?>, StructureSeparationSettings> structureSettingsMapOverworld = DimensionSettings.func_242746_i().getStructures().func_236195_a_(); //TODO 1.17 check if any PR has been accepted
-        structureSettingsMapOverworld.put(hunter_camp, HunterCampStructure.getSettings());
+        structureSettingsMapOverworld.put(hunter_camp, new ConfigurableStructureSeparationSettings(VampirismConfig.BALANCE.hunterTentDistance, VampirismConfig.BALANCE.hunterTentSeparation, 14357719));
 
-        if (VampirismConfig.SERVER.villageModify.get()) {
+        if (VampirismConfig.COMMON.villageModify.get()) {
             LOGGER.info("Replacing vanilla village structure separation settings for the overworld dimension preset");
-            structureSettingsMapOverworld.put(Structure.field_236382_r_, new StructureSeparationSettings(VampirismConfig.SERVER.villageDistance.get(), VampirismConfig.SERVER.villageSeparation.get(), DimensionStructuresSettings.field_236191_b_.get(Structure.field_236382_r_).func_236673_c_()));
+            structureSettingsMapOverworld.put(Structure.field_236382_r_, new ConfigurableStructureSeparationSettings(VampirismConfig.SERVER.villageDistance, VampirismConfig.SERVER.villageSeparation, DimensionStructuresSettings.field_236191_b_.get(Structure.field_236381_q_).func_236673_c_()));
         } else {
             LOGGER.trace("Not modifying village");
         }

--- a/src/main/java/de/teamlapen/vampirism/core/RegistryManager.java
+++ b/src/main/java/de/teamlapen/vampirism/core/RegistryManager.java
@@ -72,6 +72,7 @@ public class RegistryManager implements IInitListener {
                 ModLoot.registerLootFunctionType();
                 VampirismBiomeFeatures.init();
             case LOAD_COMPLETE:
+                event.enqueueWork(ModFeatures::registerStructureSeparation);
                 if (ModEffects.checkNightVision()) {
                     ModEffects.fixNightVisionEffecTypes();
                 }

--- a/src/main/java/de/teamlapen/vampirism/util/ConfigurableStructureSeparationSettings.java
+++ b/src/main/java/de/teamlapen/vampirism/util/ConfigurableStructureSeparationSettings.java
@@ -1,0 +1,35 @@
+package de.teamlapen.vampirism.util;
+
+import de.teamlapen.vampirism.config.BalanceConfig;
+import net.minecraft.world.gen.settings.StructureSeparationSettings;
+import net.minecraftforge.common.ForgeConfigSpec;
+import org.apache.logging.log4j.LogManager;
+
+
+public class ConfigurableStructureSeparationSettings extends StructureSeparationSettings {
+
+    private final ForgeConfigSpec.IntValue distanceConf;
+    private final ForgeConfigSpec.IntValue separationConf;
+
+
+    public ConfigurableStructureSeparationSettings(ForgeConfigSpec.IntValue distanceConf, ForgeConfigSpec.IntValue separationConf, int salt) {
+        super(distanceConf.get(), separationConf.get(), salt); //At this point the config is probably not loaded yet
+        this.distanceConf = distanceConf;
+        this.separationConf = separationConf;
+    }
+
+    @Override
+    public int func_236668_a_() {
+        int dist = distanceConf.get();
+        if (dist <= func_236671_b_()) {
+            LogManager.getLogger(BalanceConfig.class).warn("config value 'distance' must be greater than 'separation'. 'distance' increased");
+            dist = func_236671_b_() + 1;
+        }
+        return dist;
+    }
+
+    @Override
+    public int func_236671_b_() {
+        return separationConf.get();
+    }
+}

--- a/src/main/java/de/teamlapen/vampirism/world/gen/structures/huntercamp/HunterCampStructure.java
+++ b/src/main/java/de/teamlapen/vampirism/world/gen/structures/huntercamp/HunterCampStructure.java
@@ -1,8 +1,6 @@
 package de.teamlapen.vampirism.world.gen.structures.huntercamp;
 
 import com.mojang.serialization.Codec;
-import de.teamlapen.vampirism.config.BalanceConfig;
-import de.teamlapen.vampirism.config.VampirismConfig;
 import net.minecraft.util.math.MutableBoundingBox;
 import net.minecraft.util.registry.DynamicRegistries;
 import net.minecraft.world.biome.Biome;
@@ -11,22 +9,12 @@ import net.minecraft.world.gen.feature.NoFeatureConfig;
 import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.gen.feature.structure.StructureStart;
 import net.minecraft.world.gen.feature.template.TemplateManager;
-import net.minecraft.world.gen.settings.StructureSeparationSettings;
-import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class HunterCampStructure extends Structure<NoFeatureConfig> {
-
-    public static StructureSeparationSettings getSettings() {
-        if (VampirismConfig.BALANCE.hunterTentDistance.get() <= VampirismConfig.BALANCE.hunterTentSeparation.get()) {
-            LogManager.getLogger(BalanceConfig.class).warn("config value 'hunterTentDistance' is not set greater than 'hunterTentSeparation'. 'hunterTentDistance' increased");
-            VampirismConfig.BALANCE.hunterTentDistance.set(VampirismConfig.BALANCE.hunterTentSeparation.get() + 1);
-        }
-        return new StructureSeparationSettings(VampirismConfig.BALANCE.hunterTentDistance.get(),VampirismConfig.BALANCE.hunterTentSeparation.get(),14357719);
-    }
 
     public HunterCampStructure(Codec<NoFeatureConfig> deserializer) {
         super(deserializer);


### PR DESCRIPTION
 Allow configuration by using a configurable subclass of StructureSeparationSettings.

 Fixes #830
However, terraforged does not seem to respect the configuration.
