### PR TITLE
add modcompat for api dependent runnables

### DIFF
--- a/src/api/java/de/teamlapen/vampirism/api/VampirismAPI.java
+++ b/src/api/java/de/teamlapen/vampirism/api/VampirismAPI.java
@@ -21,6 +21,8 @@ import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.util.LazyOptional;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class for core api methods
@@ -45,6 +47,17 @@ public class VampirismAPI {
     private static IEntityActionManager entityActionManager;
     private static IWorldGenManager worldGenRegistry;
     private static IExtendedBrewingRecipeRegistry extendedBrewingRecipeRegistry;
+
+    private static boolean init;
+    private static List<Runnable> apiRunnables = new ArrayList<>();
+
+    public static void runAPIDependent(Runnable runnable) {
+        if (init) {
+            runnable.run();
+        } else {
+            apiRunnables.add(runnable);
+        }
+    }
 
     public static ISkillManager skillManager() {
         return skillManager;
@@ -110,7 +123,8 @@ public class VampirismAPI {
         entityActionManager = entityActionManagerIn;
         worldGenRegistry = worldGenRegistryIn;
         extendedBrewingRecipeRegistry = extendedBrewingRecipeRegistryIn;
-
+        init = true;
+        apiRunnables.forEach(Runnable::run);
     }
 
     /**


### PR DESCRIPTION
The Problem is, that the API is setup in the VampirismMod constructor but needed in Werewolves constructor (Mods are loaded randomly)

I can not call https://github.com/TeamLapen/Vampirism/blob/d85fdd78f35d194b47898c17ca4562053a3f7380/src/main/java/de/teamlapen/vampirism/data/recipebuilder/SkillNodeBuilder.java#L46 in gatherdata without registering the faction, but the modbus events are not fired in run data, so i cannot register the faction outside the constructor.

This exact issue can also be resolved by adding another `faction(Resourcelocation loc)` method, but there might be other places where the playable faction is needed before the setup event.