### PR TITLE
Check for null in LootingLevelEvent

### DIFF
--- a/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
@@ -283,7 +283,7 @@ public class ModEntityEventHandler {
 
     @SubscribeEvent
     public void onEntityLootingEvent(LootingLevelEvent event){
-        if(event.getDamageSource().getTrueSource() instanceof PlayerEntity){
+        if(event.getDamageSource() != null && event.getDamageSource().getTrueSource() instanceof PlayerEntity){
             @Nullable
             IItemWithTier.TIER hunterCoatTier = VampirismPlayerAttributes.get((PlayerEntity) event.getDamageSource().getTrueSource()).getHuntSpecial().fullHunterCoat;
             if(hunterCoatTier== IItemWithTier.TIER.ENHANCED || hunterCoatTier== IItemWithTier.TIER.ULTIMATE){


### PR DESCRIPTION
Unfortunately, due to interactions with global loot modifiers, the damage source can be null in LootingLevelEvent. This fix avoids a potential null pointer exception by checking to make sure that the damage source is indeed not null.