### PR TITLE
Allow external modification of the minion visibility & capabilities

### DIFF
--- a/src/main/java/de/teamlapen/vampirism/client/model/HunterMinionModel.java
+++ b/src/main/java/de/teamlapen/vampirism/client/model/HunterMinionModel.java
@@ -1,11 +1,11 @@
 package de.teamlapen.vampirism.client.model;
 
+import de.teamlapen.vampirism.client.renderer.entity.layers.PlayerBodyOverlayLayer;
 import de.teamlapen.vampirism.entity.minion.HunterMinionEntity;
 import net.minecraft.client.model.AnimationUtils;
-import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.model.geom.ModelPart;
 
-public class HunterMinionModel<T extends HunterMinionEntity> extends PlayerModel<T> {
+public class HunterMinionModel<T extends HunterMinionEntity> extends PlayerBodyOverlayLayer.VisibilityPlayerModel<T> {
 
     public HunterMinionModel(ModelPart p_170821_, boolean p_170822_) {
         super(p_170821_, p_170822_);

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/AdvancedHunterRenderer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/AdvancedHunterRenderer.java
@@ -31,7 +31,7 @@ public class AdvancedHunterRenderer extends HumanoidMobRenderer<AdvancedHunterEn
 
     public AdvancedHunterRenderer(EntityRendererProvider.@NotNull Context context) {
         super(context, new BasicHunterModel<>(context.bakeLayer(ModEntitiesRender.HUNTER), false), 0.5F);
-        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), h -> HunterEquipmentModel.StakeType.FULL, e -> HunterEquipmentModel.HatType.from(e.getHunterType())));
+        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), h -> HunterEquipmentModel.StakeType.FULL, e -> HunterEquipmentModel.HatType.from(e.getHunterType()), getModel().hat));
         this.addLayer(new CloakLayer<>(this, textureCloak, advancedHunterEntity -> true));
         if (VampirismConfig.CLIENT.renderAdvancedMobPlayerFaces.get()) {
             this.addLayer(new PlayerFaceOverlayLayer<>(this));

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/BasicHunterRenderer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/BasicHunterRenderer.java
@@ -14,6 +14,8 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 
 /**
  * There are differently looking level 0 hunters.
@@ -29,7 +31,7 @@ public class BasicHunterRenderer extends DualBipedRenderer<BasicHunterEntity, Ba
 
     public BasicHunterRenderer(EntityRendererProvider.@NotNull Context context) {
         super(context, new BasicHunterModel<>(context.bakeLayer(ModEntitiesRender.HUNTER), false), new BasicHunterModel<>(context.bakeLayer(ModEntitiesRender.HUNTER_SLIM), true), 0.5F);
-        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), entity -> entity.isHoldingCrossbow() ? HunterEquipmentModel.StakeType.NONE : entity.getEntityLevel() < 2 ? HunterEquipmentModel.StakeType.ONLY : HunterEquipmentModel.StakeType.FULL, entity -> entity.getEntityLevel() == 0 ? HunterEquipmentModel.HatType.from(entity.getEntityTextureType() % 3) : HunterEquipmentModel.HatType.HAT1));
+        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), entity -> entity.isHoldingCrossbow() ? HunterEquipmentModel.StakeType.NONE : entity.getEntityLevel() < 2 ? HunterEquipmentModel.StakeType.ONLY : HunterEquipmentModel.StakeType.FULL, entity -> entity.getEntityLevel() == 0 ? HunterEquipmentModel.HatType.from(entity.getEntityTextureType() % 3) : HunterEquipmentModel.HatType.HAT1, () -> Optional.of(this.getModel().hat)));
         this.addLayer(new CloakLayer<>(this, textureCloak, entity -> entity.getEntityLevel() > 0));
         textures = gatherTextures("textures/entity/hunter", true);
     }

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/HunterMinionRenderer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/HunterMinionRenderer.java
@@ -19,6 +19,8 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 /**
  * There are differently looking level 0 hunters.
  * Hunter as of level 1 look all the same, but have different weapons
@@ -34,7 +36,7 @@ public class HunterMinionRenderer extends DualBipedRenderer<HunterMinionEntity, 
         textures = gatherTextures("textures/entity/hunter", true);
         minionSpecificTextures = gatherTextures("textures/entity/minion/hunter", false);
         this.addLayer(new PlayerBodyOverlayLayer<>(this));
-        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), minion -> minion.getItemBySlot(EquipmentSlot.MAINHAND).isEmpty() ? minion.getItemBySlot(EquipmentSlot.OFFHAND).isEmpty() ? HunterEquipmentModel.StakeType.FULL : HunterEquipmentModel.StakeType.AXE_ONLY : HunterEquipmentModel.StakeType.NONE, e -> HunterEquipmentModel.HatType.from(e.getHatType())));
+        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), minion -> minion.getItemBySlot(EquipmentSlot.MAINHAND).isEmpty() ? minion.getItemBySlot(EquipmentSlot.OFFHAND).isEmpty() ? HunterEquipmentModel.StakeType.FULL : HunterEquipmentModel.StakeType.AXE_ONLY : HunterEquipmentModel.StakeType.NONE, e -> HunterEquipmentModel.HatType.from(e.getHatType()), () -> Optional.of(this.getModel().hat)));
         this.addLayer(new HumanoidArmorLayer<>(this, new HumanoidModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED_ARMOR_INNER)), new HumanoidModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED_ARMOR_OUTER))));
     }
 

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/HunterTaskMasterRenderer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/HunterTaskMasterRenderer.java
@@ -7,6 +7,7 @@ import de.teamlapen.vampirism.client.model.HunterEquipmentModel;
 import de.teamlapen.vampirism.client.renderer.entity.layers.HunterEquipmentLayer;
 import de.teamlapen.vampirism.client.renderer.entity.layers.TaskMasterTypeLayer;
 import de.teamlapen.vampirism.entity.hunter.HunterTaskMasterEntity;
+import de.teamlapen.vampirism.mixin.client.VillagerModelAccessor;
 import net.minecraft.client.model.VillagerModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
@@ -29,7 +30,7 @@ public class HunterTaskMasterRenderer extends MobRenderer<HunterTaskMasterEntity
         super(context, new VillagerModel<>(context.bakeLayer(ModEntitiesRender.TASK_MASTER)), 0.5F);
 //        this.addLayer(new HeldItemLayer<>(this));
         this.addLayer(new TaskMasterTypeLayer<>(this, overlay));
-        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), h -> HunterEquipmentModel.StakeType.NONE, h -> HunterEquipmentModel.HatType.HAT2));
+        this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), h -> HunterEquipmentModel.StakeType.NONE, h -> HunterEquipmentModel.HatType.HAT2, ((VillagerModelAccessor) getModel()).getHat()));
     }
 
     @NotNull

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/HunterTrainerRenderer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/HunterTrainerRenderer.java
@@ -24,7 +24,7 @@ public class HunterTrainerRenderer extends HumanoidMobRenderer<Mob, PlayerModel<
     public HunterTrainerRenderer(EntityRendererProvider.@NotNull Context context, boolean renderEquipment) {
         super(context, new PlayerModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED), false), 0.5F);
         if (renderEquipment) {
-            this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), h -> HunterEquipmentModel.StakeType.ONLY, entityModel -> HunterEquipmentModel.HatType.HAT2));
+            this.addLayer(new HunterEquipmentLayer<>(this, context.getModelSet(), h -> HunterEquipmentModel.StakeType.ONLY, entityModel -> HunterEquipmentModel.HatType.HAT2, getModel().hat));
         }
         //this.addLayer(new CloakLayer<>(this, textureCloak, Predicates.alwaysTrue()));
     }

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/VampireMinionRenderer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/VampireMinionRenderer.java
@@ -4,36 +4,29 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import de.teamlapen.vampirism.client.core.ModEntitiesRender;
 import de.teamlapen.vampirism.client.renderer.entity.layers.PlayerBodyOverlayLayer;
 import de.teamlapen.vampirism.entity.minion.VampireMinionEntity;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
-import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
 @OnlyIn(Dist.CLIENT)
-public class VampireMinionRenderer extends DualBipedRenderer<VampireMinionEntity, PlayerModel<VampireMinionEntity>> {
+public class VampireMinionRenderer extends DualBipedRenderer<VampireMinionEntity, PlayerBodyOverlayLayer.VisibilityPlayerModel<VampireMinionEntity>> {
 
     private final Pair<ResourceLocation, Boolean> @NotNull [] textures;
     private final Pair<ResourceLocation, Boolean> @NotNull [] minionSpecificTextures;
 
 
     public VampireMinionRenderer(EntityRendererProvider.@NotNull Context context) {
-        super(context, new PlayerModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED), false), new PlayerModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED_SLIM), true), 0.5F);
-        ResourceManager rm = Minecraft.getInstance().getResourceManager();
+        super(context, new PlayerBodyOverlayLayer.VisibilityPlayerModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED), false), new PlayerBodyOverlayLayer.VisibilityPlayerModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED_SLIM), true), 0.5F);
         textures = gatherTextures("textures/entity/vampire", true);
         minionSpecificTextures = gatherTextures("textures/entity/minion/vampire", false);
 
         this.addLayer(new PlayerBodyOverlayLayer<>(this));
         this.addLayer(new HumanoidArmorLayer<>(this, new HumanoidModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED_ARMOR_INNER)), new HumanoidModel<>(context.bakeLayer(ModEntitiesRender.GENERIC_BIPED_ARMOR_OUTER))));
-        this.getModel().body.visible = this.getModel().jacket.visible = false;
-        this.getModel().leftArm.visible = this.getModel().leftSleeve.visible = this.getModel().rightArm.visible = this.getModel().rightSleeve.visible = false;
-        this.getModel().rightLeg.visible = this.getModel().rightPants.visible = this.getModel().leftLeg.visible = this.getModel().leftPants.visible = false;
     }
 
     public int getMinionSpecificTextureCount() {

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/layers/HunterEquipmentLayer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/layers/HunterEquipmentLayer.java
@@ -1,11 +1,13 @@
 package de.teamlapen.vampirism.client.renderer.entity.layers;
 
+import com.google.common.base.Suppliers;
 import com.mojang.blaze3d.vertex.PoseStack;
 import de.teamlapen.vampirism.REFERENCE;
 import de.teamlapen.vampirism.client.core.ModEntitiesRender;
 import de.teamlapen.vampirism.client.model.HunterEquipmentModel;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.geom.EntityModelSet;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
@@ -14,8 +16,11 @@ import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Render weapons for hunter entities
@@ -27,21 +32,27 @@ public class HunterEquipmentLayer<T extends Mob, Q extends EntityModel<T>> exten
     private final ResourceLocation textureExtra = new ResourceLocation(REFERENCE.MODID, "textures/entity/hunter_extra.png");
     private final Function<T, HunterEquipmentModel.StakeType> predicateStake;
     private final Function<T, HunterEquipmentModel.HatType> functionHat;
+    private final @NotNull Supplier<Optional<ModelPart>> hatPart;
 
     /**
      * @param predicateStake entity -> Type of equipment that should be rendered
      */
-    public HunterEquipmentLayer(@NotNull RenderLayerParent<T, Q> entityRendererIn, @NotNull EntityModelSet modelSet, Function<T, HunterEquipmentModel.StakeType> predicateStake, Function<T, HunterEquipmentModel.HatType> functionHat) {
+    public HunterEquipmentLayer(@NotNull RenderLayerParent<T, Q> entityRendererIn, @NotNull EntityModelSet modelSet, Function<T, HunterEquipmentModel.StakeType> predicateStake, Function<T, HunterEquipmentModel.HatType> functionHat, @NotNull Supplier<@NotNull Optional<ModelPart>> hatPart) {
         super(entityRendererIn);
-        equipmentModel = new HunterEquipmentModel<>(modelSet.bakeLayer(ModEntitiesRender.HUNTER_EQUIPMENT));
+        this.equipmentModel = new HunterEquipmentModel<>(modelSet.bakeLayer(ModEntitiesRender.HUNTER_EQUIPMENT));
         this.predicateStake = predicateStake;
         this.functionHat = functionHat;
+        this.hatPart = hatPart;
+    }
+
+    public HunterEquipmentLayer(@NotNull RenderLayerParent<T, Q> entityRendererIn, @NotNull EntityModelSet modelSet, Function<T, HunterEquipmentModel.StakeType> predicateStake, Function<T, HunterEquipmentModel.HatType> functionHat, @Nullable ModelPart hatPart) {
+        this(entityRendererIn, modelSet, predicateStake, functionHat, Suppliers.memoize(() -> Optional.ofNullable(hatPart)));
     }
 
     @Override
     public void render(@NotNull PoseStack matrixStackIn, @NotNull MultiBufferSource bufferIn, int packedLightIn, @NotNull T entityIn, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
         if (!entityIn.isInvisible()) {
-            equipmentModel.setHat(functionHat.apply(entityIn));
+            equipmentModel.setHat(this.hatPart.get().map(a -> a.visible).orElse(true) ? functionHat.apply(entityIn) : HunterEquipmentModel.HatType.NONE);
             equipmentModel.setWeapons(predicateStake.apply(entityIn));
 
             coloredCutoutModelCopyLayerRender(this.getParentModel(), this.equipmentModel, textureExtra, matrixStackIn, bufferIn, packedLightIn, entityIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, partialTicks, 1, 1, 1);

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/entity/layers/PlayerBodyOverlayLayer.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/entity/layers/PlayerBodyOverlayLayer.java
@@ -1,14 +1,16 @@
 package de.teamlapen.vampirism.client.renderer.entity.layers;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
+import de.teamlapen.vampirism.client.renderer.entity.DualBipedRenderer;
 import de.teamlapen.vampirism.entity.minion.MinionEntity;
-import de.teamlapen.vampirism.mixin.client.AgeableModelAccessor;
 import de.teamlapen.vampirism.util.IPlayerOverlay;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
@@ -16,30 +18,115 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This layer is supposed to render the minion with its texture or the player's body texture instead.
+ * <br>
+ * In this implementation the minion must use a {@link de.teamlapen.vampirism.client.renderer.entity.layers.PlayerBodyOverlayLayer.VisibilityPlayerModel} model which allows this layer to render the model depending on the relevant parts without changing the visibility of the {@link ModelPart}s
+ *
+ * @param <T> The minion entity
+ * @param <M> The no rendering dummy minion model
+ */
 @OnlyIn(Dist.CLIENT)
-public class PlayerBodyOverlayLayer<T extends MinionEntity<?> & IPlayerOverlay, M extends PlayerModel<T>> extends RenderLayer<T, M> {
-    public PlayerBodyOverlayLayer(@NotNull RenderLayerParent<T, M> entityRendererIn) {
+public class PlayerBodyOverlayLayer<T extends MinionEntity<?> & IPlayerOverlay, M extends PlayerBodyOverlayLayer.VisibilityPlayerModel<T>> extends RenderLayer<T, M> {
+
+    public PlayerBodyOverlayLayer(@NotNull DualBipedRenderer<T, M> entityRendererIn) {
         super(entityRendererIn);
     }
 
     @Override
     public void render(@NotNull PoseStack matrixStackIn, @NotNull MultiBufferSource bufferIn, int packedLightIn, @NotNull T entitylivingbaseIn, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
-        ResourceLocation loc = getTextureLocation(entitylivingbaseIn);
+        ResourceLocation texture = getTextureLocation(entitylivingbaseIn);
+        RenderType type = getParentModel().getRenderType(this.getParentModel(), texture, entitylivingbaseIn);
+
         if (entitylivingbaseIn.shouldRenderLordSkin()) {
-            loc = entitylivingbaseIn.getOverlayPlayerProperties().map(Pair::getLeft).orElse(loc);
+            if (type != null) {
+                getParentModel().setVisibility(VisibilityPlayerModel.Visibility.HEAD);
+                getParentModel().renderToBuffer(matrixStackIn, bufferIn.getBuffer(type), packedLightIn, OverlayTexture.NO_OVERLAY, 1, 1, 1, 1);
+            }
+
+            texture = entitylivingbaseIn.getOverlayPlayerProperties().map(Pair::getLeft).orElse(texture);
+            RenderType bodyType = getParentModel().getRenderType(this.getParentModel(), texture, entitylivingbaseIn);
+            if (bodyType != null) {
+                getParentModel().setVisibility(VisibilityPlayerModel.Visibility.BODY);
+                getParentModel().renderToBuffer(matrixStackIn, bufferIn.getBuffer(bodyType), packedLightIn, OverlayTexture.NO_OVERLAY, 1, 1, 1, 1);
+            }
+        } else if (type != null) {
+            getParentModel().setVisibility(VisibilityPlayerModel.Visibility.ALL);
+            getParentModel().renderToBuffer(matrixStackIn, bufferIn.getBuffer(type), packedLightIn, OverlayTexture.NO_OVERLAY, 1, 1, 1, 1);
+        }
+        getParentModel().setVisibility(VisibilityPlayerModel.Visibility.NONE);
+    }
+
+    /**
+     * Default {@link PlayerModel} implementation that allows to hide the head and body parts without changing the {@link ModelPart#visible} property.
+     */
+    public static class VisibilityPlayerModel<T extends MinionEntity<?>> extends PlayerModel<T> {
+
+        private @NotNull Visibility visibility = Visibility.NONE;
+        private final @NotNull Collection<ModelPart> hatList = Collections.singleton(super.hat);
+
+        public VisibilityPlayerModel(ModelPart pRoot, boolean pSlim) {
+            super(pRoot, pSlim);
         }
 
-        VertexConsumer vertexBuilder = bufferIn.getBuffer(RenderType.entityCutoutNoCull(loc));
-        ((AgeableModelAccessor) this.getParentModel()).getBodyParts_vampirism().forEach(
-                b -> b.visible = true
-        );
-        (this.getParentModel()).hat.visible = false; //For some reason the hat is part of the body parts and not head parts
-        ((AgeableModelAccessor) this.getParentModel()).getBodyParts_vampirism().forEach(b -> b.render(matrixStackIn, vertexBuilder, packedLightIn, OverlayTexture.NO_OVERLAY, 1, 1, 1, 1));
-        ((AgeableModelAccessor) this.getParentModel()).getBodyParts_vampirism().forEach(
-                b -> b.visible = false
-        );
-        (this.getParentModel()).hat.visible = true;
+        @Override
+        protected @NotNull Iterable<ModelPart> headParts() {
+            if (this.visibility.head) {
+                return Iterables.concat(super.headParts(), this.hatList);
+            } else {
+                return Collections.emptyList();
+            }
+        }
 
+        @Override
+        protected @NotNull Iterable<ModelPart> bodyParts() {
+            if (this.visibility.body) {
+                List<ModelPart> parts = Lists.newArrayList(super.bodyParts());
+                parts.remove(this.hat);
+                return parts;
+            } else {
+                return Collections.emptyList();
+            }
+        }
+
+        public void setVisibility(@NotNull Visibility type) {
+            this.visibility = type;
+        }
+
+        @Nullable
+        public RenderType getRenderType(PlayerModel<T> model, ResourceLocation location, T entity) {
+            Minecraft minecraft = Minecraft.getInstance();
+            boolean pBodyVisible = !entity.isInvisible();
+            boolean translucent = !pBodyVisible && !entity.isInvisibleTo(minecraft.player);
+            boolean flag2 = minecraft.shouldEntityAppearGlowing(entity);
+            if (translucent) {
+                return RenderType.itemEntityTranslucentCull(location);
+            } else if (pBodyVisible) {
+                return model.renderType(location);
+            } else {
+                return flag2 ? RenderType.outline(location) : null;
+            }
+        }
+
+        public enum Visibility {
+            HEAD(true, false),
+            BODY(false, true),
+            NONE(false, false),
+            ALL(true, true);
+
+            private final boolean head;
+            private final boolean body;
+
+            Visibility(boolean head, boolean body) {
+                this.head = head;
+                this.body = body;
+            }
+        }
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/hunter/BasicHunterEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/hunter/BasicHunterEntity.java
@@ -172,6 +172,7 @@ public class BasicHunterEntity extends HunterBaseEntity implements IBasicHunter,
                     if (controller.hasFreeMinionSlot()) {
                         if (fph.getCurrentFaction() == this.getFaction()) {
                             HunterMinionEntity.HunterMinionData data = new HunterMinionEntity.HunterMinionData("Minion", this.getEntityTextureType(), this.getEntityTextureType() % 4, false);
+                            data.updateEntityCaps(this.serializeCaps());
                             int id = controller.createNewMinionSlot(data, ModEntities.HUNTER_MINION.get());
                             if (id < 0) {
                                 LOGGER.error("Failed to get minion slot");

--- a/src/main/java/de/teamlapen/vampirism/entity/minion/management/MinionData.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/minion/management/MinionData.java
@@ -51,6 +51,7 @@ public class MinionData implements INBTSerializable<CompoundTag>, IMinionData {
     private final @NotNull MinionInventory inventory;
     private float health;
     private String name;
+    private @NotNull CompoundTag entityCaps = new CompoundTag();
 
 
     @NotNull
@@ -87,6 +88,7 @@ public class MinionData implements INBTSerializable<CompoundTag>, IMinionData {
                 LOGGER.error("Saved minion task does not exist anymore {}", id);
             }
         }
+        entityCaps = nbt.getCompound("caps");
     }
 
     @Override
@@ -147,6 +149,14 @@ public class MinionData implements INBTSerializable<CompoundTag>, IMinionData {
         return taskLocked;
     }
 
+    public @NotNull CompoundTag getEntityCaps() {
+        return entityCaps;
+    }
+
+    public void updateEntityCaps(CompoundTag caps) {
+        this.entityCaps = caps;
+    }
+
     public void resetStats(@NotNull MinionEntity<?> entity) {
         entity.getInventory().ifPresent(inv -> {
             if (!InventoryHelper.removeItemFromInventory(inv, new ItemStack(ModItems.OBLIVION_POTION.get()))) {
@@ -176,6 +186,7 @@ public class MinionData implements INBTSerializable<CompoundTag>, IMinionData {
             activeTaskDesc.writeToNBT(task);
             tag.put("task", task);
         }
+        tag.put("caps", entityCaps);
     }
 
     public boolean setTaskLocked(boolean locked) {

--- a/src/main/java/de/teamlapen/vampirism/entity/vampire/BasicVampireEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/vampire/BasicVampireEntity.java
@@ -162,6 +162,7 @@ public class BasicVampireEntity extends VampireBaseEntity implements IBasicVampi
                     if (controller.hasFreeMinionSlot()) {
                         if (fph.getCurrentFaction() == this.getFaction()) {
                             VampireMinionEntity.VampireMinionData data = new VampireMinionEntity.VampireMinionData("Minion", this.getEntityTextureType(), false);
+                            data.updateEntityCaps(this.serializeCaps());
                             int id = controller.createNewMinionSlot(data, ModEntities.VAMPIRE_MINION.get());
                             if (id < 0) {
                                 LOGGER.error("Failed to get minion slot");

--- a/src/main/java/de/teamlapen/vampirism/mixin/client/VillagerModelAccessor.java
+++ b/src/main/java/de/teamlapen/vampirism/mixin/client/VillagerModelAccessor.java
@@ -1,0 +1,13 @@
+package de.teamlapen.vampirism.mixin.client;
+
+import net.minecraft.client.model.VillagerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(VillagerModel.class)
+public interface VillagerModelAccessor {
+
+    @Accessor("hat")
+    ModelPart getHat();
+}

--- a/src/main/resources/vampirism.mixins.json
+++ b/src/main/resources/vampirism.mixins.json
@@ -35,7 +35,8 @@
     "client.AgeableModelAccessor",
     "client.BossOverlayGuiAccessor",
     "client.LevelRendererMixin",
-    "client.SheetsMixin"
+    "client.SheetsMixin",
+    "client.VillagerModelAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Currently the `PlayerBodyOverlayLayer` uses the visibility of the minion's `ModelPart`s to render the minion skin and player overlay separately. Bus this causes issues with the external modification of the `ModelPart`'s visibility.

With this change the vampire and hunter minions will have a dummy model that can be modified by 3rd parties but will not be rendered. The `PlayerBodyOverlayLayer` will then take over all rendering of the minion and the optional player overlay.

It will render the head separately from the body in case the player's model should be rendered. This will consider all changes to the visibility or rotations of the minion's dummy model.

Additionally the visibility of the hat will be considered when rendering the hat from the `HunterEquipmentLayer`