### PR TITLE
Make Vampirism compatible with newer and older Forge versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx3G
 # forge
 minecraft_version=1.20.1
 minecraft_version_range=[1.20.1,1.21)
-forge_version=47.1.21
+forge_version=47.1.0
 forge_version_range=[47,)
 loader_version_range=[47,)
 mappings_channel=parchment

--- a/src/main/java/de/teamlapen/vampirism/VampirismMod.java
+++ b/src/main/java/de/teamlapen/vampirism/VampirismMod.java
@@ -284,6 +284,7 @@ public class VampirismMod {
         }
 
         MinecraftForge.EVENT_BUS.register(new ModPlayerEventHandler());
+        ModPlayerEventHandler.registerEyeHeight();
 
         MinecraftForge.EVENT_BUS.register(new ModEntityEventHandler());
         MinecraftForge.EVENT_BUS.addListener(ModLootTables::onLootLoad);

--- a/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
@@ -247,9 +247,9 @@ public class ModEntityEventHandler {
     }
 
     @SubscribeEvent
-    public void onEyeHeightSet(EntityEvent.@NotNull EyeHeight event) {
+    public void onEyeHeightSet(EntityEvent.@NotNull Size event) {
         if (event.getEntity() instanceof VampireBaseEntity || event.getEntity() instanceof HunterBaseEntity) {
-            event.setNewEyeHeight(event.getOriginalEyeHeight() * 0.875f);
+            event.setNewEyeHeight(event.getOldEyeHeight() * 0.875f);
         }
         if (event.getEntity() instanceof LivingEntity) {
             //(CoffinBlock.setSleepSize(event, ((LivingEntity) event.getEntity()));

--- a/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/ModEntityEventHandler.java
@@ -20,6 +20,7 @@ import de.teamlapen.vampirism.entity.hunter.HunterBaseEntity;
 import de.teamlapen.vampirism.entity.minion.MinionEntity;
 import de.teamlapen.vampirism.entity.player.VampirismPlayerAttributes;
 import de.teamlapen.vampirism.entity.player.vampire.VampirePlayer;
+import de.teamlapen.vampirism.entity.player.vampire.actions.BatVampireAction;
 import de.teamlapen.vampirism.entity.vampire.VampireBaseEntity;
 import de.teamlapen.vampirism.items.VampirismVampireSwordItem;
 import de.teamlapen.vampirism.items.oil.EvasionOil;
@@ -62,6 +63,8 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -253,6 +256,16 @@ public class ModEntityEventHandler {
         }
         if (event.getEntity() instanceof LivingEntity) {
             //(CoffinBlock.setSleepSize(event, ((LivingEntity) event.getEntity()));
+        }
+    }
+
+    /**
+     * This is a workaround because the class {@link EntityEvent.EyeHeight} may not be available on runtime. Take a look at {@link de.teamlapen.vampirism.entity.player.ModPlayerEventHandler#registerEyeHeight()}
+     */
+    @Deprecated
+    public static <T extends EntityEvent> void eyeHeightReflect(Method setNewEyeHeight, Method getOldEyeHeight, T event) throws InvocationTargetException, IllegalAccessException {
+        if (event.getEntity() instanceof VampireBaseEntity || event.getEntity() instanceof HunterBaseEntity) {
+            setNewEyeHeight.invoke(event, ((Float) getOldEyeHeight.invoke(event)) * 0.875f);
         }
     }
 

--- a/src/main/java/de/teamlapen/vampirism/entity/player/ModPlayerEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/ModPlayerEventHandler.java
@@ -144,25 +144,14 @@ public class ModPlayerEventHandler {
     }
 
     @SubscribeEvent
-    public void size(EntityEvent.@NotNull Size event) {
+    public void eyeHeight(EntityEvent.@NotNull Size event) {
         if (event.getEntity() instanceof Player && ((Player) event.getEntity()).getInventory() != null /*make sure we are not in the player's contructor*/) {
             if (event.getEntity().isAlive() && event.getEntity().position().lengthSqr() != 0 && event.getEntity().getVehicle() == null) { //Do not attempt to get capability while entity is being initialized
                 if (VampirismPlayerAttributes.get((Player) event.getEntity()).getVampSpecial().bat) {
                     event.setNewSize(BatVampireAction.BAT_SIZE);
-                } else if (VampirismPlayerAttributes.get((Player) event.getEntity()).getVampSpecial().isDBNO) {
-                    event.setNewSize(EntityDimensions.fixed(0.6f, 0.95f));
-                }
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public void eyeHeight(EntityEvent.@NotNull EyeHeight event) {
-        if (event.getEntity() instanceof Player && ((Player) event.getEntity()).getInventory() != null /*make sure we are not in the player's contructor*/) {
-            if (event.getEntity().isAlive() && event.getEntity().position().lengthSqr() != 0 && event.getEntity().getVehicle() == null) { //Do not attempt to get capability while entity is being initialized
-                if (VampirismPlayerAttributes.get((Player) event.getEntity()).getVampSpecial().bat) {
                     event.setNewEyeHeight(BatVampireAction.BAT_EYE_HEIGHT);
                 } else if (VampirismPlayerAttributes.get((Player) event.getEntity()).getVampSpecial().isDBNO) {
+                    event.setNewSize(EntityDimensions.fixed(0.6f, 0.95f));
                     event.setNewEyeHeight(0.725f);
                 }
             }


### PR DESCRIPTION
As reasoning https://github.com/TeamLapen/Vampirism/pull/1231#issuecomment-1641186391 and https://github.com/TeamLapen/Vampirism/issues/1235

We have multiple choices here:
1. use Forge > 46.1.29
    - will work
    - forces the user to use newer forge versions
    - forces Vampirism to be removed / not added to modpacks
2. restrict Vampirism to Forge [46.1.0, 46.1.3]
    - will work
    - user will complain why Vampirism does not support newer version
    - limits the users freedom
3. try to do both
   - all forge version will be supported
   - the users can choose what to do
   - if someone complains / reports a bug we can always tell them to use Forge 46.1.3

While I do not like any of these choices I think the 3rd one is the best one given the circumstances.

This solution is based on Forge 46.1.0, keeps the old methods (we do not care about Forge `[46.1.6-46.1.29)`) and uses reflections to register the eye height event for newer versions 