### PR TITLE
Add mixin for MobType

### DIFF
--- a/src/api/java/de/teamlapen/vampirism/api/VReference.java
+++ b/src/api/java/de/teamlapen/vampirism/api/VReference.java
@@ -43,8 +43,9 @@ public class VReference {
      */
     public static MobCategory VAMPIRE_CREATURE_TYPE = MobCategory.create("vampirism_vampire", "vampirism_vampire", 30, false, false, 128);
     /**
-     * Vampire creatures have this creature attribute.
+     * Vampire creatures have this creature attribute. Note: There is a config option that makes Vampirism use UNDEAD type instead
      * Don't know why this exists alongside EnumCreatureType, but this is used by enchantments
+     * TODO 1.21 maybe replace with a getter method, if the config option still exists
      */
     @SuppressWarnings("InstantiationOfUtilityClass")
     public static MobType VAMPIRE_CREATURE_ATTRIBUTE = new MobType();

--- a/src/main/java/de/teamlapen/vampirism/config/VampirismConfig.java
+++ b/src/main/java/de/teamlapen/vampirism/config/VampirismConfig.java
@@ -142,6 +142,7 @@ public class VampirismConfig {
         public final ForgeConfigSpec.BooleanValue infectCreaturesSanguinare;
         public final ForgeConfigSpec.BooleanValue preventRenderingDebugBoundingBoxes;
         public final ForgeConfigSpec.BooleanValue allowVillageDestroyBlocks;
+        public final ForgeConfigSpec.BooleanValue vampiresAreUndeadType;
 
         public final ForgeConfigSpec.BooleanValue sundamageUnknownDimension;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> sundamageDimensionsOverridePositive;
@@ -179,6 +180,7 @@ public class VampirismConfig {
             preventRenderingDebugBoundingBoxes = builder.comment("Prevent players from enabling the rendering of debug bounding boxes. This can allow them to see certain entities they are not supposed to see (e.g. disguised hunter").define("preventDebugBoundingBoxes", false);
             batDimensionBlacklist = builder.comment("Prevent vampire players to transform into a bat").defineList("batDimensionBlacklist", Collections.singletonList(Level.END.location().toString()), string -> string instanceof String && UtilLib.isValidResourceLocation(((String) string)));
             allowVillageDestroyBlocks = builder.comment("Allow players to destroy point of interest blocks in faction villages if they no not have the faction village").define("allowVillageDestroyBlocks", false);
+            vampiresAreUndeadType = builder.comment("Change vampire players mob type to UNDEAD. May cause issues with other mods").define("vampiresAreUndeadType", false);
 
             builder.push("sundamage");
             sundamageUnknownDimension = builder.comment("Whether vampires should receive sundamage in unknown dimensions").define("sundamageUnknownDimension", false);

--- a/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedDonkeyEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedDonkeyEntity.java
@@ -2,6 +2,7 @@ package de.teamlapen.vampirism.entity.converted;
 
 import de.teamlapen.vampirism.api.VReference;
 import de.teamlapen.vampirism.config.BalanceMobProps;
+import de.teamlapen.vampirism.config.VampirismConfig;
 import de.teamlapen.vampirism.core.ModAttributes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -99,7 +100,7 @@ public class ConvertedDonkeyEntity extends Donkey implements CurableConvertedCre
     @NotNull
     @Override
     public MobType getMobType() {
-        return VReference.VAMPIRE_CREATURE_ATTRIBUTE;
+        return VampirismConfig.SERVER.vampiresAreUndeadType.get() ? MobType.UNDEAD : VReference.VAMPIRE_CREATURE_ATTRIBUTE;
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedHorseEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedHorseEntity.java
@@ -2,6 +2,7 @@ package de.teamlapen.vampirism.entity.converted;
 
 import de.teamlapen.vampirism.api.VReference;
 import de.teamlapen.vampirism.config.BalanceMobProps;
+import de.teamlapen.vampirism.config.VampirismConfig;
 import de.teamlapen.vampirism.core.ModAttributes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -94,7 +95,7 @@ public class ConvertedHorseEntity extends Horse implements CurableConvertedCreat
     @NotNull
     @Override
     public MobType getMobType() {
-        return VReference.VAMPIRE_CREATURE_ATTRIBUTE;
+        return VampirismConfig.SERVER.vampiresAreUndeadType.get() ? MobType.UNDEAD : VReference.VAMPIRE_CREATURE_ATTRIBUTE;
     }
 
     @NotNull

--- a/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedMuleEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/converted/ConvertedMuleEntity.java
@@ -2,6 +2,7 @@ package de.teamlapen.vampirism.entity.converted;
 
 import de.teamlapen.vampirism.api.VReference;
 import de.teamlapen.vampirism.config.BalanceMobProps;
+import de.teamlapen.vampirism.config.VampirismConfig;
 import de.teamlapen.vampirism.core.ModAttributes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -93,7 +94,7 @@ public class ConvertedMuleEntity extends Mule implements CurableConvertedCreatur
     @NotNull
     @Override
     public MobType getMobType() {
-        return VReference.VAMPIRE_CREATURE_ATTRIBUTE;
+        return VampirismConfig.SERVER.vampiresAreUndeadType.get() ? MobType.UNDEAD : VReference.VAMPIRE_CREATURE_ATTRIBUTE;
     }
 
     @NotNull

--- a/src/main/java/de/teamlapen/vampirism/entity/vampire/VampireBaseEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/vampire/VampireBaseEntity.java
@@ -232,7 +232,7 @@ public abstract class VampireBaseEntity extends VampirismEntity implements IVamp
     @NotNull
     @Override
     public MobType getMobType() {
-        return VReference.VAMPIRE_CREATURE_ATTRIBUTE;
+        return VampirismConfig.SERVER.vampiresAreUndeadType.get() ? MobType.UNDEAD : VReference.VAMPIRE_CREATURE_ATTRIBUTE;
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/items/enchantment/EnchantmentVampireSlayer.java
+++ b/src/main/java/de/teamlapen/vampirism/items/enchantment/EnchantmentVampireSlayer.java
@@ -1,6 +1,7 @@
 package de.teamlapen.vampirism.items.enchantment;
 
 import de.teamlapen.vampirism.api.VReference;
+import de.teamlapen.vampirism.config.VampirismConfig;
 import de.teamlapen.vampirism.items.PitchforkItem;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
@@ -36,7 +37,7 @@ public class EnchantmentVampireSlayer extends Enchantment {
 
     @Override
     public float getDamageBonus(int level, @NotNull MobType creatureType) {
-        return creatureType == VReference.VAMPIRE_CREATURE_ATTRIBUTE ? 2f + Math.min(0, level - 1) * 1F : 0;
+        return creatureType == (VampirismConfig.SERVER.vampiresAreUndeadType.get() ? MobType.UNDEAD : VReference.VAMPIRE_CREATURE_ATTRIBUTE) ? 2f + Math.min(0, level - 1) * 1F : 0;
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/mixin/MixinLivingEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/mixin/MixinLivingEntity.java
@@ -7,6 +7,8 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
@@ -17,18 +19,35 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LivingEntity.class)
 public abstract class MixinLivingEntity extends Entity {
-    private MixinLivingEntity(@NotNull EntityType<? extends LivingEntity> type, @NotNull Level worldIn) {
+    protected MixinLivingEntity(@NotNull EntityType<? extends LivingEntity> type, @NotNull Level worldIn) {
         super(type, worldIn);
     }
 
     @Shadow
     public abstract boolean addEffect(MobEffectInstance effectInstanceIn);
 
+    @Shadow
+    public abstract ItemStack getMainHandItem(); // Needed in subclass
+
+
     @Inject(method = "checkTotemDeathProtection", at = @At("RETURN"))
     private void handleTotemOfUndying(DamageSource damageSourceIn, @NotNull CallbackInfoReturnable<Boolean> cir) {
         if (cir.getReturnValue() && Helper.isVampire(this)) {
             this.addEffect(new MobEffectInstance(ModEffects.FIRE_PROTECTION.get(), 800, 5));
             this.addEffect(new MobEffectInstance(ModEffects.SUNSCREEN.get(), 800, 4));
+        }
+    }
+
+    protected MobType vampirism$getMobType() {
+        return null;
+    }
+
+    @Inject(method = "getMobType", at = @At("HEAD"), cancellable = true)
+    private void handleGetMobType(CallbackInfoReturnable<MobType> cir) {
+        MobType t = vampirism$getMobType();
+        if (t != null) {
+            cir.setReturnValue(t);
+            cir.cancel();
         }
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/mixin/MixinPlayerEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/mixin/MixinPlayerEntity.java
@@ -12,12 +12,14 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(Player.class)
 public abstract class MixinPlayerEntity extends MixinLivingEntity implements IVampirismPlayer {
 
+    @Unique
     private final VampirismPlayerAttributes vampirismPlayerAttributes = new VampirismPlayerAttributes();
 
     private MixinPlayerEntity(@NotNull EntityType<? extends LivingEntity> type, @NotNull Level worldIn) {

--- a/src/main/java/de/teamlapen/vampirism/mixin/MixinPlayerEntity.java
+++ b/src/main/java/de/teamlapen/vampirism/mixin/MixinPlayerEntity.java
@@ -1,11 +1,13 @@
 package de.teamlapen.vampirism.mixin;
 
+import de.teamlapen.vampirism.config.VampirismConfig;
 import de.teamlapen.vampirism.entity.player.IVampirismPlayer;
 import de.teamlapen.vampirism.entity.player.VampirismPlayerAttributes;
 import de.teamlapen.vampirism.util.MixinHooks;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MobType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
@@ -14,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(Player.class)
-public abstract class MixinPlayerEntity extends LivingEntity implements IVampirismPlayer {
+public abstract class MixinPlayerEntity extends MixinLivingEntity implements IVampirismPlayer {
 
     private final VampirismPlayerAttributes vampirismPlayerAttributes = new VampirismPlayerAttributes();
 
@@ -30,5 +32,13 @@ public abstract class MixinPlayerEntity extends LivingEntity implements IVampiri
     @ModifyVariable(method = "attack(Lnet/minecraft/world/entity/Entity;)V", at = @At(value = "STORE", ordinal = 0), ordinal = 1)
     public float vampireSlayerEnchantment(float damage, Entity target) {
         return damage + MixinHooks.calculateVampireSlayerEnchantments(target, this.getMainHandItem());
+    }
+
+    @Override
+    protected MobType vampirism$getMobType() {
+        if (getVampAtts().vampireLevel > 0 && VampirismConfig.SERVER.vampiresAreUndeadType.get()) {
+            return MobType.UNDEAD;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
@Cheaterpaul What do you think about this approach?
Should not really impact performance, right?
Instead of instance of check, there is a delegate method and overwrite.

My idea is to introduce #770 as optional in 1.20/1.9 and let e.g. Mario test it.
In the future we could consider making it default.
