### PR TITLE
add action disable effect

### DIFF
--- a/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IAction.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IAction.java
@@ -19,6 +19,7 @@ public interface IAction<T extends IFactionPlayer<T>> {
      * Checks if the player can use this action
      *
      * @param player Must be an instance of class that belongs to {@link IAction#getFaction()}
+     * @implNote  This only checks for action specific conditions. For a more general check use {@link de.teamlapen.vampirism.api.entity.player.actions.IActionHandler#canUseAction(IAction)}
      */
     PERM canUse(T player);
 
@@ -95,7 +96,7 @@ public interface IAction<T extends IFactionPlayer<T>> {
         /**
          * The player is not in the position to use the action.
          * <p>
-         * This is the case if the player is in spectator mode or the action rejects the player
+         * This is different from {@link PERM#PLAYER_DISALLOWED} as it is returned by a specific action when it does not allow the player to use it
          */
         DISALLOWED,
         /**
@@ -107,7 +108,13 @@ public interface IAction<T extends IFactionPlayer<T>> {
         /**
          * The user does not have the correct permission to use the action {@link de.teamlapen.vampirism.util.Permissions#ACTION}
          */
-        PERMISSION_DISALLOWED
+        PERMISSION_DISALLOWED,
+        /**
+         * The player is not in the position to use the action.
+         * <p>
+         * This is different from {@link PERM#DISALLOWED} as it is returned by the {@link IActionHandler} when the player is not able to use any action
+         */
+        PLAYER_DISALLOWED;
     }
 
     /**

--- a/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IActionHandler.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IActionHandler.java
@@ -85,6 +85,11 @@ public interface IActionHandler<T extends IFactionPlayer<T>> {
     IAction.PERM toggleAction(IAction<T> action, IAction.ActivationContext context);
 
     /**
+     * Make a complete check if the player can use the action. This includes a general check and an action specific check ({@link IAction#canUse(IFactionPlayer)})
+     */
+    IAction.PERM canUseAction(@NotNull IAction<T> action);
+
+    /**
      * Deactivate a lasting action, if it was active.
      */
     void deactivateAction(ILastingAction<T> action);

--- a/src/main/java/de/teamlapen/vampirism/client/gui/screens/SelectActionRadialScreen.java
+++ b/src/main/java/de/teamlapen/vampirism/client/gui/screens/SelectActionRadialScreen.java
@@ -71,9 +71,9 @@ public class SelectActionRadialScreen<T extends IFactionPlayer<T>> extends DualS
 
     @Override
     public void drawSlice(IRadialMenuSlot<IAction<?>> slot, boolean highlighted, GuiGraphics buffer, float x, float y, float z, float radiusIn, float radiusOut, float startAngle, float endAngle, int r, int g, int b, int a) {
-        float actionPercentage = actionHandler.getPercentageForAction((IAction) slot.primarySlotIcon());
-        if (((IAction<T>)slot.primarySlotIcon()).canUse(this.player) != IAction.PERM.ALLOWED) {
-            actionPercentage = -1;
+        float actionPercentage = -1;
+        if (actionHandler.canUseAction((IAction)slot.primarySlotIcon()) == IAction.PERM.ALLOWED) {
+            actionPercentage = actionHandler.getPercentageForAction((IAction) slot.primarySlotIcon());
         }
         if (actionPercentage == 0) {
             super.drawSlice(slot, highlighted, buffer, x, y, z, radiusIn, radiusOut, startAngle, endAngle, r, g, b, 100);

--- a/src/main/java/de/teamlapen/vampirism/core/ModEffects.java
+++ b/src/main/java/de/teamlapen/vampirism/core/ModEffects.java
@@ -56,6 +56,7 @@ public class ModEffects {
             .addAttributeModifier(ModAttributes.SUNDAMAGE.get(), "45ebd53a-14fa-4ede-b4e7-412e075a8b5f", 0.2, AttributeModifier.Operation.MULTIPLY_TOTAL)
             .addAttributeModifier(Attributes.ARMOR_TOUGHNESS, "45ebd53a-14fa-4ede-b4e7-412e075a8b5f", -0.3, AttributeModifier.Operation.MULTIPLY_TOTAL)
     );
+    public static final RegistryObject<MobEffect> ACTION_DISABLED = EFFECTS.register("action_disabled", () -> new VampirismEffect(MobEffectCategory.HARMFUL, 0x1919191));
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static MobEffect modded_night_vision;  //Substituted version

--- a/src/main/java/de/teamlapen/vampirism/entity/factions/FactionPlayerHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/factions/FactionPlayerHandler.java
@@ -16,6 +16,7 @@ import de.teamlapen.vampirism.api.entity.player.IFactionPlayer;
 import de.teamlapen.vampirism.api.entity.player.actions.IAction;
 import de.teamlapen.vampirism.config.VampirismConfig;
 import de.teamlapen.vampirism.core.ModAdvancements;
+import de.teamlapen.vampirism.core.ModEffects;
 import de.teamlapen.vampirism.core.ModTags;
 import de.teamlapen.vampirism.entity.minion.management.PlayerMinionController;
 import de.teamlapen.vampirism.entity.player.IVampirismPlayer;
@@ -31,6 +32,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.capabilities.*;
 import net.minecraftforge.common.util.LazyOptional;
@@ -570,5 +572,9 @@ public class FactionPlayerHandler implements ISyncable.ISyncableEntityCapability
             bounds.putString(String.valueOf(entry.getIntKey()), RegUtil.id(entry.getValue()).toString());
         }
         nbt.put("bound_actions", bounds);
+    }
+
+    public void onRespawn(boolean keepInventory) {
+        this.player.addEffect(new MobEffectInstance(ModEffects.ACTION_DISABLED.get(), 5 * 20));
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/player/FactionBasePlayer.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/FactionBasePlayer.java
@@ -107,6 +107,7 @@ public abstract class FactionBasePlayer<T extends IFactionPlayer<T>> implements 
     @Override
     public void onDeath(DamageSource src) {
         this.getSkillHandler().damageRefinements();
+        this.getActionHandler().resetTimers();
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism/entity/player/ModPlayerEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/ModPlayerEventHandler.java
@@ -359,6 +359,11 @@ public class ModPlayerEventHandler {
         }
     }
 
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
+        FactionPlayerHandler.get(event.getEntity()).onRespawn(event.isEndConquered());
+    }
+
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(PlayerInteractEvent.@NotNull RightClickBlock event) {
 

--- a/src/main/java/de/teamlapen/vampirism/network/ServerboundToggleActionPacket.java
+++ b/src/main/java/de/teamlapen/vampirism/network/ServerboundToggleActionPacket.java
@@ -101,6 +101,7 @@ public record ServerboundToggleActionPacket(ResourceLocation actionId, @Nullable
                         case COOLDOWN -> player.displayClientMessage(Component.translatable("text.vampirism.action.cooldown_not_over"), true);
                         case DISALLOWED -> player.displayClientMessage(Component.translatable("text.vampirism.action.disallowed"), true);
                         case PERMISSION_DISALLOWED -> player.displayClientMessage(Component.translatable("text.vampirism.action.permission_disallowed"), false);
+                        case PLAYER_DISALLOWED -> player.displayClientMessage(Component.translatable("text.vampirism.action.temporary_disabled"), true);
                         default -> {
                             //Everything alright
                         }

--- a/src/main/resources/assets/vampirism/lang/en_us.json
+++ b/src/main/resources/assets/vampirism/lang/en_us.json
@@ -148,6 +148,7 @@
   "text.vampirism.action.not_bound": "No action is bound to this key. See %s.",
   "text.vampirism.action.only_faction": "This action can only be used by players of %s faction",
   "text.vampirism.action.permission_disallowed": "You do not have the permission to use this action",
+  "text.vampirism.action.temporary_disabled": "You are not able to use an action",
   "__comment": "util",
   "itemGroup.vampirism": "Vampirism",
   "action.vampirism.cancel": "Cancel",


### PR DESCRIPTION
close #1247
- the player is not able to use actions when under the effect
- resets action timer on death


TODO:
- add effect icon and translation


While this is a rather big change for such a small feature this can be incorporated with [#1249](https://github.com/TeamLapen/Vampirism/issues/1249)