### PR TITLE
Events for Actions

### DIFF
--- a/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IActionHandler.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IActionHandler.java
@@ -93,4 +93,11 @@ public interface IActionHandler<T extends IFactionPlayer<T>> {
      * Unlock the given actions. The given action have to belong to the players faction and have to be registered
      */
     void unlockActions(Collection<IAction<T>> actions);
+
+    /**
+     *
+     * @param action Lasting Action of duration
+     * @return The modified duration of the action.
+     */
+    int getModifiedDuration(ILastingAction<T> action);
 }

--- a/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IActionHandler.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/player/actions/IActionHandler.java
@@ -93,11 +93,4 @@ public interface IActionHandler<T extends IFactionPlayer<T>> {
      * Unlock the given actions. The given action have to belong to the players faction and have to be registered
      */
     void unlockActions(Collection<IAction<T>> actions);
-
-    /**
-     *
-     * @param action Lasting Action of duration
-     * @return The modified duration of the action.
-     */
-    int getModifiedDuration(ILastingAction<T> action);
 }

--- a/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
+++ b/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
@@ -1,0 +1,129 @@
+package de.teamlapen.vampirism.api.event;
+
+import de.teamlapen.vampirism.api.entity.player.IFactionPlayer;
+import de.teamlapen.vampirism.api.entity.player.actions.IAction;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public abstract class ActionEvent extends Event {
+
+    @NotNull
+    private final IFactionPlayer<?> factionPlayer;
+    @NotNull
+    private final IAction<?> action;
+    public ActionEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action) {
+        this.factionPlayer = factionPlayer;
+        this.action = action;
+    }
+    /**
+     * @return The FactionPlayer who activated the action.
+     */
+    public @NotNull IFactionPlayer<?> getFactionPlayer() {
+        return this.factionPlayer;
+    }
+    /**
+     * @return The action the event is firing for.
+     */
+    public @NotNull IAction<?> getAction() {
+        return this.action;
+    }
+
+    /**
+     * Posted before an action fires. Use this to modify the cooldown or duration of an event
+     */
+    public static class ActionActivatedEvent extends ActionEvent {
+
+        private int cooldown;
+        private int duration;
+
+        public ActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int cooldown, int duration) {
+            super(factionPlayer, action);
+            this.cooldown = cooldown;
+            this.duration = duration;
+        }
+        /**
+         * @return The original cooldown of the action
+         */
+        public int getCooldown() {
+            return cooldown;
+        }
+        /**
+         * @param cooldown the new cooldown of the action.
+         */
+        public void setCooldown(int cooldown) {
+            this.cooldown = cooldown;
+        }
+        /**
+         * @return The original cooldown of the duration, this will return 0 if the action does not implement ILastingAction.
+         */
+        public int getDuration() {
+            return duration;
+        }
+        /**
+         * @param duration the new duration of the action.
+         */
+        public void setDuration(int duration) {
+            this.duration = duration;
+        }
+    }
+    /**
+     * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
+     */
+    public static class ActionDeactivatedEvent extends ActionEvent {
+        private final int remainingDuration;
+        public ActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
+            super(factionPlayer, action);
+            this.remainingDuration = remainingDuration;
+        }
+        /**
+         * @return The remaining cooldown of the action.
+         */
+        public int getRemainingDuration() {
+            return remainingDuration;
+        }
+
+    }
+    /**
+     * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
+     */
+    public static class ActionUpdateEvent extends ActionEvent {
+        private final int remainingDuration;
+        private boolean shouldDeactivate;
+        public ActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, boolean shouldDeactivate) {
+            super(factionPlayer, action);
+            this.remainingDuration = remainingDuration;
+            this.shouldDeactivate = shouldDeactivate;
+        }
+        /**
+         * @return The remaining cooldown of the action.
+         */
+        public int getRemainingDuration() {
+            return this.remainingDuration;
+        }
+        /**
+         * @return Whether the lasting action should be deactivated
+         */
+        public boolean shouldDeactivate() {
+            return this.shouldDeactivate;
+        }
+        /**
+         * @param deactivate If set to true, the action will deactivate. If set to false, the action will not deactivate at all on that update.
+         */
+        public void setDeactivation(boolean deactivate) {
+            this.shouldDeactivate = deactivate;
+        }
+
+    }
+    /**
+     * Posted before a player activates an action, can be used to prevent an action being fired.
+     */
+    @Cancelable
+    public static class PreActionActivatedEvent extends ActionEvent {
+        public PreActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action) {
+            super(factionPlayer, action);
+        }
+    }
+
+}

--- a/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
+++ b/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
@@ -31,7 +31,7 @@ public abstract class ActionEvent extends Event {
     }
 
     /**
-     * Posted before an action fires. Use this to modify the cooldown or duration of an event
+     * Posted after an action fires. Use this to modify the cooldown or duration of an event
      */
     public static class ActionActivatedEvent extends ActionEvent {
 
@@ -44,25 +44,25 @@ public abstract class ActionEvent extends Event {
             this.duration = duration;
         }
         /**
-         * @return The original cooldown of the action
+         * @return The original cooldown of the action, in ticks
          */
         public int getCooldown() {
             return cooldown;
         }
         /**
-         * @param cooldown the new cooldown of the action.
+         * @param cooldown the new cooldown of the action, in ticks.
          */
         public void setCooldown(int cooldown) {
             this.cooldown = cooldown;
         }
         /**
-         * @return The original cooldown of the duration, this will return 0 if the action does not implement ILastingAction.
+         * @return The original duration of the action, this will return 0 if the action does not implement ILastingAction.
          */
         public int getDuration() {
             return duration;
         }
         /**
-         * @param duration the new duration of the action.
+         * @param duration the new duration of the action, in ticks.
          */
         public void setDuration(int duration) {
             this.duration = duration;
@@ -73,17 +73,32 @@ public abstract class ActionEvent extends Event {
      */
     public static class ActionDeactivatedEvent extends ActionEvent {
         private final int remainingDuration;
-        public ActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
+        private int cooldown;
+        public ActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, int cooldown) {
             super(factionPlayer, action);
             this.remainingDuration = remainingDuration;
+            this.cooldown = cooldown;
         }
         /**
-         * @return The remaining cooldown of the action.
+         * @return The remaining duration of the action, in ticks.
          */
         public int getRemainingDuration() {
             return remainingDuration;
         }
+        /**
+         * @return The original cooldown of the action, in ticks
+         */
+        public int getCooldown() {
+            return cooldown;
+        }
 
+        /**
+         *
+         * @param cooldown The new cooldown of the action, in ticks
+         */
+        public void setCooldown(int cooldown) {
+            this.cooldown = cooldown;
+        }
     }
     /**
      * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
@@ -97,7 +112,7 @@ public abstract class ActionEvent extends Event {
             this.shouldDeactivate = shouldDeactivate;
         }
         /**
-         * @return The remaining cooldown of the action.
+         * @return The remaining duration of the action, in ticks.
          */
         public int getRemainingDuration() {
             return this.remainingDuration;

--- a/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
+++ b/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
@@ -31,8 +31,9 @@ public abstract class ActionEvent extends Event {
     }
 
     /**
-     * Posted after an action fires. Use this to modify the cooldown or duration of an event
+     * Posted before an action fires. Use this to modify the cooldown or duration of action, or to prevent the action from activating.
      */
+    @Cancelable
     public static class ActionActivatedEvent extends ActionEvent {
 
         private int cooldown;
@@ -56,7 +57,7 @@ public abstract class ActionEvent extends Event {
             this.cooldown = cooldown;
         }
         /**
-         * @return The original duration of the action, this will return 0 if the action does not implement ILastingAction.
+         * @return The original duration of the action, this will return -1 if the action does not implement ILastingAction.
          */
         public int getDuration() {
             return duration;
@@ -71,6 +72,7 @@ public abstract class ActionEvent extends Event {
     /**
      * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
      */
+
     public static class ActionDeactivatedEvent extends ActionEvent {
         private final int remainingDuration;
         private int cooldown;
@@ -130,15 +132,6 @@ public abstract class ActionEvent extends Event {
             this.shouldDeactivate = deactivate;
         }
 
-    }
-    /**
-     * Posted before a player activates an action, can be used to prevent an action being fired.
-     */
-    @Cancelable
-    public static class PreActionActivatedEvent extends ActionEvent {
-        public PreActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action) {
-            super(factionPlayer, action);
-        }
     }
 
 }

--- a/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
+++ b/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
@@ -72,7 +72,6 @@ public abstract class ActionEvent extends Event {
     /**
      * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
      */
-
     public static class ActionDeactivatedEvent extends ActionEvent {
         private final int remainingDuration;
         private int cooldown;
@@ -105,31 +104,18 @@ public abstract class ActionEvent extends Event {
     /**
      * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
      */
+    @HasResult
     public static class ActionUpdateEvent extends ActionEvent {
         private final int remainingDuration;
-        private boolean shouldDeactivate;
-        public ActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, boolean shouldDeactivate) {
+        public ActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
             super(factionPlayer, action);
             this.remainingDuration = remainingDuration;
-            this.shouldDeactivate = shouldDeactivate;
         }
         /**
          * @return The remaining duration of the action, in ticks.
          */
         public int getRemainingDuration() {
             return this.remainingDuration;
-        }
-        /**
-         * @return Whether the lasting action should be deactivated
-         */
-        public boolean shouldDeactivate() {
-            return this.shouldDeactivate;
-        }
-        /**
-         * @param deactivate If set to true, the action will deactivate. If set to false, the action will not deactivate at all on that update.
-         */
-        public void setDeactivation(boolean deactivate) {
-            this.shouldDeactivate = deactivate;
         }
 
     }

--- a/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
+++ b/src/api/java/de/teamlapen/vampirism/api/event/ActionEvent.java
@@ -13,16 +13,19 @@ public abstract class ActionEvent extends Event {
     private final IFactionPlayer<?> factionPlayer;
     @NotNull
     private final IAction<?> action;
+
     public ActionEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action) {
         this.factionPlayer = factionPlayer;
         this.action = action;
     }
+
     /**
      * @return The FactionPlayer who activated the action.
      */
     public @NotNull IFactionPlayer<?> getFactionPlayer() {
         return this.factionPlayer;
     }
+
     /**
      * @return The action the event is firing for.
      */
@@ -44,48 +47,7 @@ public abstract class ActionEvent extends Event {
             this.cooldown = cooldown;
             this.duration = duration;
         }
-        /**
-         * @return The original cooldown of the action, in ticks
-         */
-        public int getCooldown() {
-            return cooldown;
-        }
-        /**
-         * @param cooldown the new cooldown of the action, in ticks.
-         */
-        public void setCooldown(int cooldown) {
-            this.cooldown = cooldown;
-        }
-        /**
-         * @return The original duration of the action, this will return -1 if the action does not implement ILastingAction.
-         */
-        public int getDuration() {
-            return duration;
-        }
-        /**
-         * @param duration the new duration of the action, in ticks.
-         */
-        public void setDuration(int duration) {
-            this.duration = duration;
-        }
-    }
-    /**
-     * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
-     */
-    public static class ActionDeactivatedEvent extends ActionEvent {
-        private final int remainingDuration;
-        private int cooldown;
-        public ActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, int cooldown) {
-            super(factionPlayer, action);
-            this.remainingDuration = remainingDuration;
-            this.cooldown = cooldown;
-        }
-        /**
-         * @return The remaining duration of the action, in ticks.
-         */
-        public int getRemainingDuration() {
-            return remainingDuration;
-        }
+
         /**
          * @return The original cooldown of the action, in ticks
          */
@@ -94,28 +56,96 @@ public abstract class ActionEvent extends Event {
         }
 
         /**
-         *
+         * @param cooldown the new cooldown of the action, in ticks.
+         */
+        public void setCooldown(int cooldown) {
+            this.cooldown = cooldown;
+        }
+
+        /**
+         * @return The original duration of the action, this will return -1 if the action does not implement ILastingAction.
+         */
+        public int getDuration() {
+            return duration;
+        }
+
+        /**
+         * @param duration the new duration of the action, in ticks.
+         */
+        public void setDuration(int duration) {
+            this.duration = duration;
+        }
+    }
+
+    /**
+     * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
+     */
+    public static class ActionDeactivatedEvent extends ActionEvent {
+        private final int remainingDuration;
+        private int cooldown;
+
+        public ActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, int cooldown) {
+            super(factionPlayer, action);
+            this.remainingDuration = remainingDuration;
+            this.cooldown = cooldown;
+        }
+
+        /**
+         * @return The remaining duration of the action, in ticks.
+         */
+        public int getRemainingDuration() {
+            return remainingDuration;
+        }
+
+        /**
+         * @return The original cooldown of the action, in ticks
+         */
+        public int getCooldown() {
+            return cooldown;
+        }
+
+        /**
          * @param cooldown The new cooldown of the action, in ticks
          */
         public void setCooldown(int cooldown) {
             this.cooldown = cooldown;
         }
     }
+
     /**
-     * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement ILastingAction.
+     * Posted when an action deactivates, either when deactivated manually or when out of time. As regular actions instantly deactivate, this only fires for actions that implement {@link de.teamlapen.vampirism.api.entity.player.actions.ILastingAction}.
      */
     @HasResult
     public static class ActionUpdateEvent extends ActionEvent {
         private final int remainingDuration;
+        private boolean overrideDeactivation;
+
         public ActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
             super(factionPlayer, action);
             this.remainingDuration = remainingDuration;
         }
+
         /**
          * @return The remaining duration of the action, in ticks.
          */
         public int getRemainingDuration() {
             return this.remainingDuration;
+        }
+
+        /**
+         * Call this to deactivate the action. Or override the current result.
+         *
+         * @param overrideDeactivation If true, the action will be deactivated.
+         */
+        public void setOverrideDeactivation(boolean overrideDeactivation) {
+            this.overrideDeactivation = overrideDeactivation;
+        }
+
+        /**
+         * @return If true, the action will be deactivated.
+         */
+        public boolean shouldOverrideDeactivation() {
+            return this.overrideDeactivation;
         }
 
     }

--- a/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
@@ -301,6 +301,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
         ResourceLocation id = RegUtil.id(action);
         if (activeTimers.containsKey(id)) {
             deactivateAction((ILastingAction<T>) action);
+            this.activeTimers.removeInt(id);
             dirty = true;
             return IAction.PERM.ALLOWED;
         } else if (cooldownTimers.containsKey(id)) {

--- a/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
@@ -264,6 +264,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
         }
         activeTimers.clear();
         cooldownTimers.clear();
+        modifiedCooldownTimers.clear();
         dirty = true;
     }
 
@@ -272,6 +273,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
         ILastingAction<T> lastingAction = (ILastingAction<T>) action;
         deactivateAction(lastingAction, true);
         cooldownTimers.removeInt(RegUtil.id(action));
+        modifiedCooldownTimers.removeInt(RegUtil.id(action));
 
     }
     /**
@@ -352,7 +354,6 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
                 }
                 //Entries should to be at least 1
                 cooldownTimers.put(id, Math.max(cooldown, 1));
-                modifiedCooldownTimers.removeInt(id);
                 activeTimers.put(id, 1);
             }
             modifiedDurationTimer.removeInt(id);
@@ -385,6 +386,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
             Object2IntMap.Entry<ResourceLocation> entry = it.next();
             int value = entry.getIntValue();
             if (value <= 1) { //<= Just in case we have missed something
+                modifiedCooldownTimers.removeInt(entry);
                 it.remove();
             } else {
                 entry.setValue(value - 1);
@@ -403,7 +405,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
                     cooldownTimers.put(entry.getKey(), modifiedCooldownTimers.getInt(RegUtil.id(action)));
                 }
                 it.remove();//Do not access entry after this
-                modifiedCooldownTimers.removeInt(RegUtil.id(action));
+
                 dirty = true;
             } else {
                 boolean shouldDeactivate= action.onUpdate(player);

--- a/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
@@ -303,20 +303,20 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
             if(isCancelled) return IAction.PERM.DISALLOWED;
             IAction.PERM r = action.canUse(player);
             if (r == IAction.PERM.ALLOWED) {
-                int duration = 0;
-                if (action instanceof ILastingAction) {
-                    duration = ((ILastingAction<T>) action).getDuration(player);
-                }
-                //We need to know the modified duration before the action is activated for actions such as sunscreen
-                ActionEvent.ActionActivatedEvent activationEvent = VampirismEventFactory.fireActionActivatedEvent(player, action, action.getCooldown(player), duration);
-                modifiedDurationTimer.put(id, activationEvent.getDuration());
+
                 if (action.onActivated(player, context)) {
                     ModStats.updateActionUsed(player.getRepresentingPlayer(), action);
+                    int duration = 0;
+                    if (action instanceof ILastingAction) {
+                        duration = ((ILastingAction<T>) action).getDuration(player);
+                    }
+                    ActionEvent.ActionActivatedEvent activationEvent = VampirismEventFactory.fireActionActivatedEvent(player, action, action.getCooldown(player), duration);
                     //Even though lasting actions do not activate their cooldown until they deactivate
                     //we probably want to keep this here so that they are edited by one event.
                     int cooldown = activationEvent.getCooldown();
                     modifiedCooldownTimers.put(id, cooldown);
                     if (action instanceof ILastingAction) {
+                        modifiedDurationTimer.put(id, activationEvent.getDuration());
                         duration = activationEvent.getDuration();
                         activeTimers.put(id, duration);
                     } else {

--- a/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
@@ -371,10 +371,11 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
             if(!ignoreCooldown && !cooldownTimers.containsKey(id)) {
                 if(!fullCooldown) {
                     cooldown -= cooldown * (leftTime / (float) duration / 2f);
+                } else {
+                    expectedCooldownTimes.put(id, cooldown);
                 }
                 //Entries should to be at least 1
                 cooldownTimers.put(id, Math.max(cooldown, 1));
-                expectedCooldownTimes.put(id, cooldown);
                 activeTimers.put(id, 1);
             }
             expectedDurations.removeInt(id);

--- a/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
@@ -120,10 +120,10 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
     public float getPercentageForAction(@NotNull IAction<T> action) {
         ResourceLocation id = RegUtil.id(action);
         if (activeTimers.containsKey(id)) {
-            return activeTimers.getInt(id) / ((float) modifiedDurationTimer.getOrDefault(id, ((ILastingAction<T>) action).getDuration(player)));
+            return activeTimers.getInt(id) / ((float) modifiedDurationTimer.getInt(id));
         }
         if (cooldownTimers.containsKey(id)) {
-            return -cooldownTimers.getInt(id) / (float) modifiedCooldownTimers.getOrDefault(id, action.getCooldown(player));
+            return -cooldownTimers.getInt(id) / (float) modifiedCooldownTimers.getInt(id);
         }
         return 0f;
     }
@@ -265,15 +265,19 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
         activeTimers.clear();
         cooldownTimers.clear();
         modifiedCooldownTimers.clear();
+        modifiedDurationTimer.clear();
         dirty = true;
     }
 
     @Override
     public void resetTimer(@NotNull IAction<T> action) {
-        ILastingAction<T> lastingAction = (ILastingAction<T>) action;
-        deactivateAction(lastingAction, true);
-        cooldownTimers.removeInt(RegUtil.id(action));
-        modifiedCooldownTimers.removeInt(RegUtil.id(action));
+        ResourceLocation id = RegUtil.id(action);
+        if(action instanceof ILastingAction<T> lastingAction) {
+            deactivateAction(lastingAction, true);
+        }
+        cooldownTimers.removeInt(id);
+        modifiedCooldownTimers.removeInt(id);
+        dirty = true;
 
     }
     /**
@@ -335,10 +339,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
                         cooldownTimers.put(id, cooldown);
                     }
                     dirty = true;
-                } else {
-                    modifiedDurationTimer.removeInt(id);
                 }
-
                 return IAction.PERM.ALLOWED;
             } else {
                 return r;
@@ -420,7 +421,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
             if (newtimer == 0) {
                 deactivateAction(action, true);
                 if(!cooldownTimers.containsKey(entry.getKey())) {
-                    cooldownTimers.put(entry.getKey(), modifiedCooldownTimers.getInt(RegUtil.id(action)));
+                    cooldownTimers.put(entry.getKey(), modifiedCooldownTimers.getInt(entry.getKey()));
                 }
                 it.remove();//Do not access entry after this
 

--- a/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
@@ -104,13 +104,6 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
             activeTimers.put(RegUtil.id(action), i + duration);
         }
     }
-    public int getModifiedDuration(ILastingAction<T> action) {
-        ResourceLocation id = RegUtil.id(action);
-        if(modifiedDurationTimer.containsKey(id)) {
-            return modifiedDurationTimer.getInt(id);
-        }
-        return action.getDuration(player);
-    }
 
     @Override
     public @NotNull List<IAction<T>> getAvailableActions() {

--- a/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/actions/ActionHandler.java
@@ -422,9 +422,7 @@ public class ActionHandler<T extends IFactionPlayer<T>> implements IActionHandle
             assert action != null;
             if (newtimer == 0) {
                 deactivateAction(action, true);
-                if(!cooldownTimers.containsKey(entry.getKey())) {
-                    cooldownTimers.put(entry.getKey(), expectedCooldownTimes.getInt(entry.getKey()));
-                }
+                cooldownTimers.put(entry.getKey(), expectedCooldownTimes.getInt(entry.getKey()));
                 it.remove();//Do not access entry after this
 
                 dirty = true;

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/HalfInvulnerableAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/HalfInvulnerableAction.java
@@ -48,14 +48,16 @@ public class HalfInvulnerableAction extends DefaultVampireAction implements ILas
     }
 
     @Override
-    public boolean onUpdate(IVampirePlayer player) {
+    public boolean onUpdate(IVampirePlayer vampire) {
+        if (!vampire.isRemote() && vampire.getRepresentingPlayer().tickCount % 20 == 0) {
+            addEffectInstance(vampire, new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 22, 1, false, false));
+        }
         return false;
     }
 
     @Override
     protected boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
         ((VampirePlayer) vampire).getSpecialAttributes().half_invulnerable = true;
-        addEffectInstance(vampire, new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, vampire.getActionHandler().getModifiedDuration(this) - 1, 1, false, false));
         return true;
     }
 

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/HalfInvulnerableAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/HalfInvulnerableAction.java
@@ -55,7 +55,7 @@ public class HalfInvulnerableAction extends DefaultVampireAction implements ILas
     @Override
     protected boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
         ((VampirePlayer) vampire).getSpecialAttributes().half_invulnerable = true;
-        addEffectInstance(vampire, new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, getDuration(vampire) - 1, 1, false, false));
+        addEffectInstance(vampire, new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, vampire.getActionHandler().getModifiedDuration(this) - 1, 1, false, false));
         return true;
     }
 

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RageVampireAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RageVampireAction.java
@@ -17,7 +17,7 @@ public class RageVampireAction extends DefaultVampireAction implements ILastingA
 
     @Override
     public boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
-        int duration = getDuration(vampire);
+        int duration = vampire.getActionHandler().getModifiedDuration(this);
         addEffectInstance(vampire, new MobEffectInstance(MobEffects.MOVEMENT_SPEED, duration, 2, false, false));
         addEffectInstance(vampire, new MobEffectInstance(MobEffects.DAMAGE_BOOST, duration, 0, false, false));
         addEffectInstance(vampire, new MobEffectInstance(MobEffects.DIG_SPEED, duration, 0, false, false));

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RageVampireAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RageVampireAction.java
@@ -17,11 +17,6 @@ public class RageVampireAction extends DefaultVampireAction implements ILastingA
 
     @Override
     public boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
-        int duration = vampire.getActionHandler().getModifiedDuration(this);
-        addEffectInstance(vampire, new MobEffectInstance(MobEffects.MOVEMENT_SPEED, duration, 2, false, false));
-        addEffectInstance(vampire, new MobEffectInstance(MobEffects.DAMAGE_BOOST, duration, 0, false, false));
-        addEffectInstance(vampire, new MobEffectInstance(MobEffects.DIG_SPEED, duration, 0, false, false));
-
         return true;
     }
 
@@ -64,6 +59,13 @@ public class RageVampireAction extends DefaultVampireAction implements ILastingA
 
     @Override
     public boolean onUpdate(IVampirePlayer vampire) {
+        if (!vampire.isRemote() && vampire.getRepresentingPlayer().tickCount % 20 == 0) {
+            int duration = 22;
+            addEffectInstance(vampire, new MobEffectInstance(MobEffects.MOVEMENT_SPEED, duration, 2, false, false));
+            addEffectInstance(vampire, new MobEffectInstance(MobEffects.DAMAGE_BOOST, duration, 0, false, false));
+            addEffectInstance(vampire, new MobEffectInstance(MobEffects.DIG_SPEED, duration, 0, false, false));
+        }
+
         return false;
     }
 

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RegenVampireAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RegenVampireAction.java
@@ -15,7 +15,6 @@ public class RegenVampireAction extends DefaultVampireAction implements ILasting
 
     @Override
     public boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
-        addEffectInstance(vampire, new MobEffectInstance(MobEffects.REGENERATION, vampire.getActionHandler().getModifiedDuration(this), vampire.getSkillHandler().isRefinementEquipped(ModRefinements.REGENERATION.get()) ? 1 : 0));
         return true;
     }
 
@@ -60,7 +59,10 @@ public class RegenVampireAction extends DefaultVampireAction implements ILasting
     }
 
     @Override
-    public boolean onUpdate(IVampirePlayer player) {
+    public boolean onUpdate(IVampirePlayer vampire) {
+        if (!vampire.isRemote() && vampire.getRepresentingPlayer().tickCount % 20 == 0) {
+            addEffectInstance(vampire, new MobEffectInstance(MobEffects.REGENERATION, 22, vampire.getSkillHandler().isRefinementEquipped(ModRefinements.REGENERATION.get()) ? 1 : 0, false, false));
+        }
         return false;
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RegenVampireAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/RegenVampireAction.java
@@ -1,5 +1,6 @@
 package de.teamlapen.vampirism.entity.player.vampire.actions;
 
+import de.teamlapen.vampirism.api.entity.player.actions.ILastingAction;
 import de.teamlapen.vampirism.api.entity.player.vampire.DefaultVampireAction;
 import de.teamlapen.vampirism.api.entity.player.vampire.IVampirePlayer;
 import de.teamlapen.vampirism.config.VampirismConfig;
@@ -10,17 +11,11 @@ import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
 
 
-public class RegenVampireAction extends DefaultVampireAction {
-
-    public RegenVampireAction() {
-        super();
-    }
+public class RegenVampireAction extends DefaultVampireAction implements ILastingAction<IVampirePlayer> {
 
     @Override
     public boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
-        Player player = vampire.getRepresentingPlayer();
-        int dur = VampirismConfig.BALANCE.vaRegenerationDuration.get() * 20;
-        player.addEffect(new MobEffectInstance(MobEffects.REGENERATION, dur, vampire.getSkillHandler().isRefinementEquipped(ModRefinements.REGENERATION.get()) ? 1 : 0));
+        addEffectInstance(vampire, new MobEffectInstance(MobEffects.REGENERATION, vampire.getActionHandler().getModifiedDuration(this), vampire.getSkillHandler().isRefinementEquipped(ModRefinements.REGENERATION.get()) ? 1 : 0));
         return true;
     }
 
@@ -37,5 +32,35 @@ public class RegenVampireAction extends DefaultVampireAction {
     @Override
     public boolean showHudCooldown(Player player) {
         return true;
+    }
+    @Override
+    public boolean showHudDuration(Player player) {
+        return true;
+    }
+
+
+    @Override
+    public int getDuration(IVampirePlayer player) {
+        return VampirismConfig.BALANCE.vaRegenerationDuration.get() * 20;
+    }
+
+    @Override
+    public void onActivatedClient(IVampirePlayer player) {
+
+    }
+
+    @Override
+    public void onDeactivated(IVampirePlayer player) {
+        removePotionEffect(player, MobEffects.REGENERATION);
+    }
+
+    @Override
+    public void onReActivated(IVampirePlayer player) {
+
+    }
+
+    @Override
+    public boolean onUpdate(IVampirePlayer player) {
+        return false;
     }
 }

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/SunscreenVampireAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/SunscreenVampireAction.java
@@ -14,7 +14,6 @@ public class SunscreenVampireAction extends DefaultVampireAction implements ILas
 
     @Override
     public boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
-        addEffectInstance(vampire, new MobEffectInstance(ModEffects.SUNSCREEN.get(), vampire.getActionHandler().getModifiedDuration(this), 3, false, false));
         return true;
     }
 
@@ -55,6 +54,10 @@ public class SunscreenVampireAction extends DefaultVampireAction implements ILas
 
     @Override
     public boolean onUpdate(IVampirePlayer vampire) {
+        if (!vampire.isRemote() && vampire.getRepresentingPlayer().tickCount % 20 == 0) {
+            addEffectInstance(vampire, new MobEffectInstance(ModEffects.SUNSCREEN.get(), 22, 3, false, false));
+        }
+
         return false;
     }
 

--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/SunscreenVampireAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/SunscreenVampireAction.java
@@ -14,7 +14,7 @@ public class SunscreenVampireAction extends DefaultVampireAction implements ILas
 
     @Override
     public boolean activate(@NotNull IVampirePlayer vampire, ActivationContext context) {
-        addEffectInstance(vampire, new MobEffectInstance(ModEffects.SUNSCREEN.get(), getDuration(vampire), 3, false, false));
+        addEffectInstance(vampire, new MobEffectInstance(ModEffects.SUNSCREEN.get(), vampire.getActionHandler().getModifiedDuration(this), 3, false, false));
         return true;
     }
 
@@ -22,6 +22,7 @@ public class SunscreenVampireAction extends DefaultVampireAction implements ILas
     public int getCooldown(IVampirePlayer player) {
         return VampirismConfig.BALANCE.vaSunscreenCooldown.get() * 20;
     }
+
 
     @Override
     public int getDuration(@NotNull IVampirePlayer player) {

--- a/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
+++ b/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
@@ -89,10 +89,11 @@ public class VampirismEventFactory {
         MinecraftForge.EVENT_BUS.post(event);
         return event.getCooldown();
     }
-    public static Event.Result fireActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
+
+    public static ActionEvent.ActionUpdateEvent fireActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
         ActionEvent.ActionUpdateEvent event = new ActionEvent.ActionUpdateEvent(factionPlayer, action, remainingDuration);
         MinecraftForge.EVENT_BUS.post(event);
-        return event.getResult();
+        return event;
     }
 
 }

--- a/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
+++ b/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
@@ -2,9 +2,12 @@ package de.teamlapen.vampirism.util;
 
 import de.teamlapen.vampirism.api.entity.factions.IFactionPlayerHandler;
 import de.teamlapen.vampirism.api.entity.factions.IPlayableFaction;
+import de.teamlapen.vampirism.api.entity.player.IFactionPlayer;
+import de.teamlapen.vampirism.api.entity.player.actions.IAction;
 import de.teamlapen.vampirism.api.entity.player.vampire.IDrinkBloodContext;
 import de.teamlapen.vampirism.api.entity.player.vampire.IVampirePlayer;
 import de.teamlapen.vampirism.api.entity.vampire.IVampire;
+import de.teamlapen.vampirism.api.event.ActionEvent;
 import de.teamlapen.vampirism.api.event.BloodDrinkEvent;
 import de.teamlapen.vampirism.api.event.PlayerFactionEvent;
 import de.teamlapen.vampirism.api.event.VampirismVillageEvent;
@@ -75,6 +78,25 @@ public class VampirismEventFactory {
         BloodDrinkEvent.EntityDrinkBloodEvent event = new BloodDrinkEvent.EntityDrinkBloodEvent(vampire, amount, saturationAmount, useRemaining, bloodSource);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
+    }
+    public static boolean firePreActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action) {
+        ActionEvent.PreActionActivatedEvent event = new ActionEvent.PreActionActivatedEvent(factionPlayer, action);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.isCanceled();
+    }
+    public static @NotNull ActionEvent.ActionActivatedEvent fireActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int cooldown, int duration) {
+        ActionEvent.ActionActivatedEvent event = new ActionEvent.ActionActivatedEvent(factionPlayer, action, cooldown, duration);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+    public static void fireActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
+        ActionEvent.ActionDeactivatedEvent event = new ActionEvent.ActionDeactivatedEvent(factionPlayer, action, remainingDuration);
+        MinecraftForge.EVENT_BUS.post(event);
+    }
+    public static boolean fireActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, boolean shouldDeactivate) {
+        ActionEvent.ActionUpdateEvent event = new ActionEvent.ActionUpdateEvent(factionPlayer, action, remainingDuration, shouldDeactivate);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.shouldDeactivate();
     }
 
 }

--- a/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
+++ b/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
@@ -89,9 +89,10 @@ public class VampirismEventFactory {
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }
-    public static void fireActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
-        ActionEvent.ActionDeactivatedEvent event = new ActionEvent.ActionDeactivatedEvent(factionPlayer, action, remainingDuration);
+    public static int fireActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, int cooldown) {
+        ActionEvent.ActionDeactivatedEvent event = new ActionEvent.ActionDeactivatedEvent(factionPlayer, action, remainingDuration, cooldown);
         MinecraftForge.EVENT_BUS.post(event);
+        return event.getCooldown();
     }
     public static boolean fireActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, boolean shouldDeactivate) {
         ActionEvent.ActionUpdateEvent event = new ActionEvent.ActionUpdateEvent(factionPlayer, action, remainingDuration, shouldDeactivate);

--- a/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
+++ b/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
@@ -79,11 +79,6 @@ public class VampirismEventFactory {
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }
-    public static boolean firePreActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action) {
-        ActionEvent.PreActionActivatedEvent event = new ActionEvent.PreActionActivatedEvent(factionPlayer, action);
-        MinecraftForge.EVENT_BUS.post(event);
-        return event.isCanceled();
-    }
     public static @NotNull ActionEvent.ActionActivatedEvent fireActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int cooldown, int duration) {
         ActionEvent.ActionActivatedEvent event = new ActionEvent.ActionActivatedEvent(factionPlayer, action, cooldown, duration);
         MinecraftForge.EVENT_BUS.post(event);

--- a/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
+++ b/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
@@ -89,10 +89,10 @@ public class VampirismEventFactory {
         MinecraftForge.EVENT_BUS.post(event);
         return event.getCooldown();
     }
-    public static boolean fireActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, boolean shouldDeactivate) {
-        ActionEvent.ActionUpdateEvent event = new ActionEvent.ActionUpdateEvent(factionPlayer, action, remainingDuration, shouldDeactivate);
+    public static Event.Result fireActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration) {
+        ActionEvent.ActionUpdateEvent event = new ActionEvent.ActionUpdateEvent(factionPlayer, action, remainingDuration);
         MinecraftForge.EVENT_BUS.post(event);
-        return event.shouldDeactivate();
+        return event.getResult();
     }
 
 }


### PR DESCRIPTION
This adds 4 new events to the action system to allow for some degree of modification of existing actions. These actions are `ActionActivatedEvent`,  `ActionDeactivatedEvent`, `ActionUpdateEvent` and `PreActionActivatedEvent`.

`PreActionActivatedEvent` allows an action to be cancelled before it is activated.

`ActionActivatedEvent` allows the cooldown of an action to be changed, as well as the duration for lasting actions.

`ActionDeactivatedEvent` allows for the cooldown of an action to be changed before it is deactivated.

`ActionUpdateEvent` allows is fired for every action update, but does not allow for any part of the action to be changed.

Additionally, lasting actions that add potion effects (such as sunscreen or rage) have been moved to applying the effect every 20 ticks under `onUpdate`. Previously, the potion effects were only added once when first activated. The regeneration vampire action also has been moved to a lasting action due to all the other similar actions being lasting actions already.