### PR TITLE
Event for Vampire Fog Distance and Blood Food Mod Parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following labeling scheme is used:
 - BugraaK _Textures/Models_
 - MrVityaTrash _Textures_
 - FrostedOver _Textures_
-- Grid _Textures_
+- Grid _Models/Textures/Structures_
 - T_Corvus _Textures_
 
 ## API

--- a/src/api/java/de/teamlapen/vampirism/api/event/VampireFogEvent.java
+++ b/src/api/java/de/teamlapen/vampirism/api/event/VampireFogEvent.java
@@ -1,0 +1,37 @@
+package de.teamlapen.vampirism.api.event;
+
+import net.minecraft.client.player.LocalPlayer;
+import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class VampireFogEvent extends Event {
+    private final LocalPlayer player;
+    private float fogDistanceMultiplier;
+
+    public VampireFogEvent(@NotNull LocalPlayer player, float fogDistanceMultiplier) {
+        this.player = player;
+        this.fogDistanceMultiplier = fogDistanceMultiplier;
+    }
+
+    /**
+     * @return The Player that is seeing the fog.
+     */
+    @NotNull
+    public LocalPlayer getPlayer() {
+        return player;
+    }
+    /**
+     * @return The fog distance multiplier of vampire fog.
+     */
+    public float getFogDistanceMultiplier() {
+        return fogDistanceMultiplier;
+    }
+
+    /**
+     * @param fogDistanceMultiplier The fog distance multiplier of vampire fog
+     */
+    public void setFogDistanceMultiplier(float fogDistanceMultiplier) {
+        this.fogDistanceMultiplier = fogDistanceMultiplier;
+    }
+}

--- a/src/api/java/de/teamlapen/vampirism/api/event/VampireFogEvent.java
+++ b/src/api/java/de/teamlapen/vampirism/api/event/VampireFogEvent.java
@@ -1,26 +1,15 @@
 package de.teamlapen.vampirism.api.event;
 
-import net.minecraft.client.player.LocalPlayer;
 import net.neoforged.bus.api.Event;
-import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("unused")
 public class VampireFogEvent extends Event {
-    private final LocalPlayer player;
     private float fogDistanceMultiplier;
 
-    public VampireFogEvent(@NotNull LocalPlayer player, float fogDistanceMultiplier) {
-        this.player = player;
+    public VampireFogEvent(float fogDistanceMultiplier) {
         this.fogDistanceMultiplier = fogDistanceMultiplier;
     }
 
-    /**
-     * @return The Player that is seeing the fog.
-     */
-    @NotNull
-    public LocalPlayer getPlayer() {
-        return player;
-    }
     /**
      * @return The fog distance multiplier of vampire fog.
      */

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/RenderHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/RenderHandler.java
@@ -149,6 +149,8 @@ public class RenderHandler implements ResourceManagerReloadListener {
                 vampireBiomeFogDistanceMultiplier = vampire.getLevel() > 0 ? 2 : 1;
                 vampireBiomeFogDistanceMultiplier += vampire.getSkillHandler().isRefinementEquipped(ModRefinements.VISTA.get()) ? VampirismConfig.BALANCE.vrVistaMod.get().floatValue() : 0;
 
+                vampireBiomeFogDistanceMultiplier = VampirismEventFactory.fireVampireFogEvent(vampireBiomeFogDistanceMultiplier);
+
             } else {
                 insideFog = false;
             }
@@ -162,9 +164,6 @@ public class RenderHandler implements ResourceManagerReloadListener {
                 vampireBiomeTicks--;
             }
         }
-
-        VampireFogEvent vampireFogEvent = VampirismEventFactory.fireVampireFogEvent(mc.player, vampireBiomeFogDistanceMultiplier);
-        vampireBiomeFogDistanceMultiplier = vampireFogEvent.getFogDistanceMultiplier();
     }
 
     @SubscribeEvent

--- a/src/main/java/de/teamlapen/vampirism/client/renderer/RenderHandler.java
+++ b/src/main/java/de/teamlapen/vampirism/client/renderer/RenderHandler.java
@@ -2,9 +2,9 @@ package de.teamlapen.vampirism.client.renderer;
 
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import de.teamlapen.lib.util.OptifineHandler;
-import de.teamlapen.vampirism.REFERENCE;
 import de.teamlapen.vampirism.api.entity.IExtendedCreatureVampirism;
 import de.teamlapen.vampirism.api.entity.hunter.IHunterMob;
+import de.teamlapen.vampirism.api.event.VampireFogEvent;
 import de.teamlapen.vampirism.api.items.IItemWithTier;
 import de.teamlapen.vampirism.api.util.VResourceLocation;
 import de.teamlapen.vampirism.blocks.CoffinBlock;
@@ -19,6 +19,7 @@ import de.teamlapen.vampirism.items.CrucifixItem;
 import de.teamlapen.vampirism.mixin.client.accessor.CameraAccessor;
 import de.teamlapen.vampirism.util.Helper;
 import de.teamlapen.vampirism.util.MixinHooks;
+import de.teamlapen.vampirism.util.VampirismEventFactory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.PlayerModel;
@@ -52,6 +53,7 @@ import java.util.Optional;
 /**
  * Handle most general rendering related stuff
  */
+@SuppressWarnings("unused")
 public class RenderHandler implements ResourceManagerReloadListener {
     private static final int ENTITY_NEAR_SQ_DISTANCE = 100;
     @NotNull
@@ -160,6 +162,9 @@ public class RenderHandler implements ResourceManagerReloadListener {
                 vampireBiomeTicks--;
             }
         }
+
+        VampireFogEvent vampireFogEvent = VampirismEventFactory.fireVampireFogEvent(mc.player, vampireBiomeFogDistanceMultiplier);
+        vampireBiomeFogDistanceMultiplier = vampireFogEvent.getFogDistanceMultiplier();
     }
 
     @SubscribeEvent

--- a/src/main/java/de/teamlapen/vampirism/core/ModItems.java
+++ b/src/main/java/de/teamlapen/vampirism/core/ModItems.java
@@ -146,7 +146,7 @@ public class ModItems {
     public static final DeferredItem<HunterIntelItem> HUNTER_INTEL_8 = register("hunter_intel_8", () -> new HunterIntelItem(8));
     public static final DeferredItem<HunterIntelItem> HUNTER_INTEL_9 = register("hunter_intel_9", () -> new HunterIntelItem(9));
 
-    public static final DeferredItem<VampirismItemBloodFoodItem> HUMAN_HEART = register("human_heart", () -> new VampirismItemBloodFoodItem((new FoodProperties.Builder()).nutrition(20).saturationModifier(1.5F).build(), new FoodProperties.Builder().nutrition(5).saturationModifier(1f).build()));
+    public static final DeferredItem<VampirismItemBloodFoodItem> HUMAN_HEART = register("human_heart", () -> new VampirismItemBloodFoodItem(new Item.Properties().food(new FoodProperties.Builder().nutrition(5).saturationModifier(1f).build()), new FoodProperties.Builder().nutrition(20).saturationModifier(1.5F).build()));
 
     public static final DeferredItem<InjectionItem> INJECTION_EMPTY = register("injection_empty", () -> new InjectionItem(InjectionItem.TYPE.EMPTY));
     public static final DeferredItem<InjectionItem> INJECTION_GARLIC = register("injection_garlic", () -> new InjectionItem(InjectionItem.TYPE.GARLIC));
@@ -191,7 +191,7 @@ public class ModItems {
     public static final DeferredItem<VampireBloodBottleItem> VAMPIRE_BLOOD_BOTTLE = register("vampire_blood_bottle", VampireBloodBottleItem::new);
     public static final DeferredItem<VampireBookItem> VAMPIRE_BOOK = register("vampire_book", VampireBookItem::new);
     public static final DeferredItem<VampireFangItem> VAMPIRE_FANG = register("vampire_fang", VampireFangItem::new);
-    public static final DeferredItem<VampirismItemBloodFoodItem> WEAK_HUMAN_HEART = register("weak_human_heart", () -> new VampirismItemBloodFoodItem((new FoodProperties.Builder()).nutrition(10).saturationModifier(0.9F).build(), new FoodProperties.Builder().nutrition(3).saturationModifier(1f).build()));
+    public static final DeferredItem<VampirismItemBloodFoodItem> WEAK_HUMAN_HEART = register("weak_human_heart", () -> new VampirismItemBloodFoodItem(new Item.Properties().food(new FoodProperties.Builder().nutrition(3).saturationModifier(1f).build()), new FoodProperties.Builder().nutrition(10).saturationModifier(0.9F).build()));
 
     public static final DeferredItem<SpawnEggItem> VAMPIRE_SPAWN_EGG = register("vampire_spawn_egg", CreativeModeTabs.SPAWN_EGGS, () -> new DeferredSpawnEggItem(ModEntities.VAMPIRE, 0x8B15A3, 0xa735e3, new Item.Properties()));
     public static final DeferredItem<SpawnEggItem> VAMPIRE_HUNTER_SPAWN_EGG = register("vampire_hunter_spawn_egg", CreativeModeTabs.SPAWN_EGGS, () -> new DeferredSpawnEggItem(ModEntities.HUNTER, 0x2d05f2, 0x2600e0, new Item.Properties()));

--- a/src/main/java/de/teamlapen/vampirism/items/VampirismItemBloodFoodItem.java
+++ b/src/main/java/de/teamlapen/vampirism/items/VampirismItemBloodFoodItem.java
@@ -1,5 +1,6 @@
 package de.teamlapen.vampirism.items;
 
+import de.teamlapen.vampirism.VampirismMod;
 import de.teamlapen.vampirism.api.entity.vampire.IVampire;
 import de.teamlapen.vampirism.entity.player.vampire.VampirePlayer;
 import de.teamlapen.vampirism.entity.vampire.DrinkBloodContext;
@@ -15,13 +16,14 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class VampirismItemBloodFoodItem extends Item {
 
     private final FoodProperties vampireFood;
 
-    public VampirismItemBloodFoodItem(FoodProperties vampireFood, @NotNull FoodProperties humanFood) {
-        super(new Properties().food(humanFood));
+    public VampirismItemBloodFoodItem(Properties properties, FoodProperties vampireFood) {
+        super(properties);
         this.vampireFood = vampireFood;
     }
 
@@ -45,5 +47,12 @@ public class VampirismItemBloodFoodItem extends Item {
         return stack;
     }
 
+    @Override
+    public @Nullable FoodProperties getFoodProperties(@NotNull ItemStack stack, @Nullable LivingEntity entity) {
+        if (entity == null) {
+            entity = VampirismMod.proxy.getClientPlayer();
+        }
 
+        return Helper.isVampire(entity) ? vampireFood : super.getFoodProperties(stack, entity);
+    }
 }

--- a/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
+++ b/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
@@ -8,11 +8,9 @@ import de.teamlapen.vampirism.api.entity.player.actions.ILastingAction;
 import de.teamlapen.vampirism.api.entity.player.vampire.IDrinkBloodContext;
 import de.teamlapen.vampirism.api.entity.player.vampire.IVampirePlayer;
 import de.teamlapen.vampirism.api.entity.vampire.IVampire;
-import de.teamlapen.vampirism.api.event.ActionEvent;
-import de.teamlapen.vampirism.api.event.BloodDrinkEvent;
-import de.teamlapen.vampirism.api.event.PlayerFactionEvent;
-import de.teamlapen.vampirism.api.event.VampirismVillageEvent;
+import de.teamlapen.vampirism.api.event.*;
 import de.teamlapen.vampirism.api.world.ITotem;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.npc.Villager;
 import net.neoforged.neoforge.common.NeoForge;
@@ -80,11 +78,13 @@ public class VampirismEventFactory {
         NeoForge.EVENT_BUS.post(event);
         return event;
     }
+
     public static @NotNull ActionEvent.ActionActivatedEvent fireActionActivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int cooldown, int duration) {
         ActionEvent.ActionActivatedEvent event = new ActionEvent.ActionActivatedEvent(factionPlayer, action, cooldown, duration);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }
+
     public static int fireActionDeactivatedEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull IAction<?> action, int remainingDuration, int cooldown) {
         ActionEvent.ActionDeactivatedEvent event = new ActionEvent.ActionDeactivatedEvent(factionPlayer, action, remainingDuration, cooldown);
         NeoForge.EVENT_BUS.post(event);
@@ -93,6 +93,12 @@ public class VampirismEventFactory {
 
     public static ActionEvent.ActionUpdateEvent fireActionUpdateEvent(@NotNull IFactionPlayer<?> factionPlayer, @NotNull ILastingAction<?> action, int remainingDuration) {
         ActionEvent.ActionUpdateEvent event = new ActionEvent.ActionUpdateEvent(factionPlayer, action, remainingDuration);
+        NeoForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static VampireFogEvent fireVampireFogEvent(@NotNull LocalPlayer player, float fogDistanceMultiplier) {
+        VampireFogEvent event = new VampireFogEvent(player, fogDistanceMultiplier);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
+++ b/src/main/java/de/teamlapen/vampirism/util/VampirismEventFactory.java
@@ -97,10 +97,10 @@ public class VampirismEventFactory {
         return event;
     }
 
-    public static VampireFogEvent fireVampireFogEvent(@NotNull LocalPlayer player, float fogDistanceMultiplier) {
-        VampireFogEvent event = new VampireFogEvent(player, fogDistanceMultiplier);
+    public static float fireVampireFogEvent(float fogDistanceMultiplier) {
+        VampireFogEvent event = new VampireFogEvent(fogDistanceMultiplier);
         NeoForge.EVENT_BUS.post(event);
-        return event;
+        return event.getFogDistanceMultiplier();
     }
 
 }

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -35,7 +35,7 @@ config = "vampirism.mixins.json"
      - BugraaK (textures/models)
      - MrVityaTrash (textures)
      - FrostedOver (textures)
-     - Grid (textures)
+     - Grid (textures/models/structures)
      - T_Corvus (textures)
      - freesound.org (sounds)
      - freeSFX.co.uk (sounds)'''


### PR DESCRIPTION
This adds a new event: `VampireFogEvent` which is fired after the `vampireBiomeFogDistanceMultiplier` is calculated in the RenderHandler. It allows add-on mods to change its value.

It also adds `getFoodProperties` to `VampirismItemBloodFoodItem` mostly for parity with other mods. If the player is a vampire it returns `vampireFood`, if not then the default food properties. AppleSkin mod uses getFoodProperties method to get the food value, so adding this will make it show the correct values for vampire players, like on this screenshot.
<img width="300" alt="Screenshot 2024-08-16 at 19 10 46" src="https://github.com/user-attachments/assets/3c78276e-f472-424b-88da-0c35f4ab74b5">
Also, I added Properties parameter to `VampirismItemBloodFoodItem` constructor in case someone wants to extend this class.

(I also added in readme near my nickname that I also did structures in models, hope you don't mind)