### PR TITLE
Add new hunter skill: Crucifix Repell

### DIFF
--- a/src/api/java/de/teamlapen/vampirism/api/client/VIngameOverlays.java
+++ b/src/api/java/de/teamlapen/vampirism/api/client/VIngameOverlays.java
@@ -1,7 +1,6 @@
 package de.teamlapen.vampirism.api.client;
 
 import de.teamlapen.vampirism.api.util.VResourceLocation;
-import net.minecraft.client.gui.LayeredDraw;
 import net.minecraft.resources.ResourceLocation;
 
 /**
@@ -14,8 +13,6 @@ public class VIngameOverlays {
      * <br>
      * Is rendered above {@link net.neoforged.neoforge.client.gui.VanillaGuiLayers#FOOD_LEVEL}, but the food rendering is canceled
      */
-    @Deprecated(forRemoval = true)
-    public static LayeredDraw.Layer BLOOD_BAR_ELEMENT;
     public static final ResourceLocation BLOOD_BAR_ID = VResourceLocation.mod("blood_bar");
 
 
@@ -24,8 +21,6 @@ public class VIngameOverlays {
      * <br>
      * Is rendered above {@link net.neoforged.neoforge.client.gui.VanillaGuiLayers#BOSS_OVERLAY}
      */
-    @Deprecated(forRemoval = true)
-    public static LayeredDraw.Layer FACTION_RAID_BAR_ELEMENT;
     public static final ResourceLocation FACTION_RAID_BAR_ID = VResourceLocation.mod("raid_bar");
 
 
@@ -34,8 +29,6 @@ public class VIngameOverlays {
      * <br>
      * Is rendered above {@link net.neoforged.neoforge.client.gui.VanillaGuiLayers#EXPERIENCE_BAR}
      */
-    @Deprecated(forRemoval = true)
-    public static LayeredDraw.Layer FACTION_LEVEL_ELEMENT;
     public static final ResourceLocation FACTION_LEVEL_ID = VResourceLocation.mod("faction_level");
 
     /**
@@ -43,8 +36,6 @@ public class VIngameOverlays {
      * <br>
      * Is rendered in the lower left corner
      */
-    @Deprecated(forRemoval = true)
-    public static LayeredDraw.Layer ACTION_COOLDOWN_ELEMENT;
     public static final ResourceLocation ACTION_COOLDOWN_ID = VResourceLocation.mod("action_cooldown");
 
     /**
@@ -52,8 +43,6 @@ public class VIngameOverlays {
      * <br>
      * Is rendered in the lower right corner
      */
-    @Deprecated(forRemoval = true)
-    public static LayeredDraw.Layer ACTION_DURATION_ELEMENT;
     public static final ResourceLocation ACTION_DURATION_ID = VResourceLocation.mod("action_duration");
     public static final ResourceLocation RAGE = VResourceLocation.mod("rage");
     public static final ResourceLocation BAT = VResourceLocation.mod("bat");

--- a/src/api/java/de/teamlapen/vampirism/api/entity/player/skills/ISkillHandler.java
+++ b/src/api/java/de/teamlapen/vampirism/api/entity/player/skills/ISkillHandler.java
@@ -19,6 +19,10 @@ public interface ISkillHandler<T extends ISkillPlayer<T>> {
         return VampirismAPI.factionPlayerHandler(player).getSkillHandler();
     }
 
+    static <T extends ISkillPlayer<T>> boolean isSkillEnabled(Player player, Holder<ISkill<?>> skill) {
+        return get(player).map(handler -> handler.isSkillEnabled(skill)).orElse(false);
+    }
+
     /**
      * @return Returns false if the skill already is unlocked or the parent node is not unlocked or the skill is not found
      */

--- a/src/generated/resources/data/vampirism/vampirism/skill_node/hunter/alchemy6.json
+++ b/src/generated/resources/data/vampirism/vampirism/skill_node/hunter/alchemy6.json
@@ -1,5 +1,6 @@
 {
   "skills": [
-    "vampirism:hunter_awareness"
+    "vampirism:hunter_awareness",
+    "vampirism:crucifix_repel"
   ]
 }

--- a/src/main/java/de/teamlapen/vampirism/client/VampirismModClient.java
+++ b/src/main/java/de/teamlapen/vampirism/client/VampirismModClient.java
@@ -6,12 +6,12 @@ import de.teamlapen.lib.util.OptifineHandler;
 import de.teamlapen.vampirism.REFERENCE;
 import de.teamlapen.vampirism.VampirismMod;
 import de.teamlapen.vampirism.api.VampirismAPI;
-import de.teamlapen.vampirism.api.client.VIngameOverlays;
 import de.teamlapen.vampirism.blocks.LogBlock;
 import de.teamlapen.vampirism.client.config.ModFilter;
 import de.teamlapen.vampirism.client.core.*;
 import de.teamlapen.vampirism.client.gui.ScreenEventHandler;
-import de.teamlapen.vampirism.client.gui.overlay.*;
+import de.teamlapen.vampirism.client.gui.overlay.CustomBossEventOverlay;
+import de.teamlapen.vampirism.client.gui.overlay.VampirismHUDOverlay;
 import de.teamlapen.vampirism.client.renderer.RenderHandler;
 import de.teamlapen.vampirism.client.renderer.VampirismClientEntityRegistry;
 import de.teamlapen.vampirism.proxy.ClientProxy;
@@ -76,8 +76,6 @@ public class VampirismModClient {
         if (OptifineHandler.isOptifineLoaded()) {
             LOGGER.warn("Using Optifine. Expect visual glitches and reduces blood vision functionality if using shaders.");
         }
-
-        setupApi();
     }
 
     public void onAddReloadListenerEvent(@NotNull AddReloadListenerEvent event) {
@@ -116,14 +114,6 @@ public class VampirismModClient {
 
     public void clearBossBarOverlay() {
         this.bossInfoOverlay.clear();
-    }
-
-    private void setupApi() {
-        VIngameOverlays.FACTION_RAID_BAR_ELEMENT = this.bossInfoOverlay;
-        VIngameOverlays.BLOOD_BAR_ELEMENT = new BloodBarOverlay();
-        VIngameOverlays.FACTION_LEVEL_ELEMENT = new FactionLevelOverlay();
-        VIngameOverlays.ACTION_COOLDOWN_ELEMENT = new ActionCooldownOverlay();
-        VIngameOverlays.ACTION_DURATION_ELEMENT = new ActionDurationOverlay();
     }
 
     public VampirismHUDOverlay getOverlay() {

--- a/src/main/java/de/teamlapen/vampirism/client/core/ModScreens.java
+++ b/src/main/java/de/teamlapen/vampirism/client/core/ModScreens.java
@@ -1,10 +1,8 @@
 package de.teamlapen.vampirism.client.core;
 
 import de.teamlapen.vampirism.api.client.VIngameOverlays;
-import de.teamlapen.vampirism.client.gui.overlay.BatOverlay;
-import de.teamlapen.vampirism.client.gui.overlay.DisguiseOverlay;
-import de.teamlapen.vampirism.client.gui.overlay.RageOverlay;
-import de.teamlapen.vampirism.client.gui.overlay.SunOverlay;
+import de.teamlapen.vampirism.client.VampirismModClient;
+import de.teamlapen.vampirism.client.gui.overlay.*;
 import de.teamlapen.vampirism.client.gui.screens.*;
 import de.teamlapen.vampirism.client.gui.screens.diffuser.FogDiffuserScreen;
 import de.teamlapen.vampirism.client.gui.screens.diffuser.GarlicDiffuserScreen;
@@ -38,13 +36,12 @@ public class ModScreens {
         event.register(ModMenus.FOG_DIFFUSER.get(), FogDiffuserScreen::new);
     }
 
-    @SuppressWarnings("removal")
     static void registerScreenOverlays(@NotNull RegisterGuiLayersEvent event) {
-        event.registerAbove(VanillaGuiLayers.EXPERIENCE_BAR, VIngameOverlays.FACTION_LEVEL_ID, VIngameOverlays.FACTION_LEVEL_ELEMENT);
-        event.registerAbove(VanillaGuiLayers.BOSS_OVERLAY, VIngameOverlays.FACTION_RAID_BAR_ID, VIngameOverlays.FACTION_RAID_BAR_ELEMENT);
-        event.registerAbove(VanillaGuiLayers.FOOD_LEVEL, VIngameOverlays.BLOOD_BAR_ID, VIngameOverlays.BLOOD_BAR_ELEMENT);
-        event.registerAboveAll(VIngameOverlays.ACTION_COOLDOWN_ID, VIngameOverlays.ACTION_COOLDOWN_ELEMENT);
-        event.registerAboveAll(VIngameOverlays.ACTION_DURATION_ID, VIngameOverlays.ACTION_DURATION_ELEMENT);
+        event.registerAbove(VanillaGuiLayers.EXPERIENCE_BAR, VIngameOverlays.FACTION_LEVEL_ID, new FactionLevelOverlay());
+        event.registerAbove(VanillaGuiLayers.BOSS_OVERLAY, VIngameOverlays.FACTION_RAID_BAR_ID, VampirismModClient.getINSTANCE().getBossInfoOverlay());
+        event.registerAbove(VanillaGuiLayers.FOOD_LEVEL, VIngameOverlays.BLOOD_BAR_ID, new BloodBarOverlay());
+        event.registerAboveAll(VIngameOverlays.ACTION_COOLDOWN_ID, new ActionCooldownOverlay<>());
+        event.registerAboveAll(VIngameOverlays.ACTION_DURATION_ID, new ActionDurationOverlay<>());
         event.registerAbove(VanillaGuiLayers.CAMERA_OVERLAYS, VIngameOverlays.RAGE, new RageOverlay());
         event.registerAbove(VanillaGuiLayers.CAMERA_OVERLAYS, VIngameOverlays.BAT, new BatOverlay());
         event.registerAbove(VanillaGuiLayers.CAMERA_OVERLAYS, VIngameOverlays.DISGUISE, new DisguiseOverlay());

--- a/src/main/java/de/teamlapen/vampirism/client/gui/screens/VampirismContainerScreen.java
+++ b/src/main/java/de/teamlapen/vampirism/client/gui/screens/VampirismContainerScreen.java
@@ -106,9 +106,10 @@ public class VampirismContainerScreen extends AbstractContainerScreen<VampirismM
                 graphics.renderItem(stack, x, y);
                 graphics.renderItemDecorations(this.font, stack, x, y, null);
             }
+
+            this.renderAccessorySlots(graphics, mouseX, mouseY, partialTicks);
         }
 
-        this.renderAccessorySlots(graphics, mouseX, mouseY, partialTicks);
 
         this.renderTooltip(graphics, mouseX, mouseY);
         if (this.menu.areRefinementsAvailable()) {

--- a/src/main/java/de/teamlapen/vampirism/entity/player/hunter/skills/HunterSkills.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/hunter/skills/HunterSkills.java
@@ -81,6 +81,7 @@ public class HunterSkills {
     public static final DeferredHolder<ISkill<?>, ISkill<IHunterPlayer>> DOUBLE_IT = SKILLS.register("double_it", () -> new VampirismSkill.SimpleHunterSkill(2, true));
     public static final DeferredHolder<ISkill<?>, ISkill<IHunterPlayer>> MASTER_CRAFTSMANSHIP = SKILLS.register("master_craftsmanship", () -> new VampirismSkill.SimpleHunterSkill(3, true));
     public static final DeferredHolder<ISkill<?>, ISkill<IHunterPlayer>> AXE2 = SKILLS.register("axe2", () -> new VampirismSkill.SimpleHunterSkill(3, true));
+    public static final DeferredHolder<ISkill<?>, ISkill<IHunterPlayer>> CRUCIFIX_REPEL = SKILLS.register("crucifix_repel", () -> new VampirismSkill.SimpleHunterSkill(2, true));
 
     @ApiStatus.Internal
     public static void register(IEventBus bus) {
@@ -134,7 +135,7 @@ public class HunterSkills {
             context.register(ALCHEMY3, new SkillNode(GARLIC_DIFFUSER));
             context.register(ALCHEMY4, new SkillNode(PURIFIED_GARLIC, GARLIC_DIFFUSER_IMPROVED));
             context.register(ALCHEMY5, new SkillNode(ENHANCED_BLESSING, ULTIMATE_CRUCIFIX));
-            context.register(ALCHEMY6, new SkillNode(HUNTER_AWARENESS));
+            context.register(ALCHEMY6, new SkillNode(HUNTER_AWARENESS, CRUCIFIX_REPEL));
 
             context.register(POTION1, new SkillNode(MULTITASK_BREWING));
             context.register(POTION2, new SkillNode(DURABLE_BREWING, CONCENTRATED_BREWING));


### PR DESCRIPTION
A new hunter skill that makes the active effect of the crucifix into a weaker passive effect. But it adds a new active effect that pushes effected entities further back. The passive effect is disabled for the duration of the cooldown.

TODO:
- [ ] texture
- [ ] skill tree placement
- [ ] balancing
- [ ] testing

Original description:
> There should be a new skill which will allow hunter players to push vampires await with a crucifix.
If the skill is not unlocked, the crucifix will work like it works now, but as soon as the skill is unlocked the now active effect will become a debuffed passive. The active effect on the other hand will be a one time action to push vampires away. While the item is on cooldown the passive should be disabled