### PR TITLE
Improvements to faction villager spawns and curable converted creatures

### DIFF
--- a/projects/faction-api/src/main/java/de/teamlapen/faction/api/event/FactionVillageEvent.java
+++ b/projects/faction-api/src/main/java/de/teamlapen/faction/api/event/FactionVillageEvent.java
@@ -3,6 +3,8 @@ package de.teamlapen.faction.api.event;
 import de.teamlapen.faction.api.factions.IFaction;
 import de.teamlapen.faction.api.world.ITotem;
 import net.minecraft.core.Holder;
+import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.npc.villager.Villager;
 import net.minecraft.world.level.Level;
@@ -11,10 +13,7 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @SuppressWarnings("unused")
 public abstract class FactionVillageEvent extends Event {
@@ -48,6 +47,7 @@ public abstract class FactionVillageEvent extends Event {
         return totem.getVillageAreaReduced();
     }
 
+    @Nullable
     public Level getLevel() {
         return this.totem.getTileLevel();
     }
@@ -62,19 +62,20 @@ public abstract class FactionVillageEvent extends Event {
     public static class SpawnNewVillager extends FactionVillageEvent {
 
         /**
-         * Random existing villager in totemTile
-         * Used as a "seed" villager to get a valid spawn point.
+         * If an existing entity is to be replaced, it is available here
          */
         @Nullable
-        private final LivingEntity oldEntity;
-        private final boolean replace;
-        private Villager newVillager;
+        private final LivingEntity replacedEntity;
 
-        public SpawnNewVillager(ITotem totem, @Nullable LivingEntity oldEntity, Villager newVillager, boolean replace) {
+        @Nullable
+        private Villager newVillager;
+        private final EntityType<? extends Villager> originalNewVillagerType;
+
+        public SpawnNewVillager(ITotem totem, EntityType<? extends Villager> newVillagerType, @Nullable LivingEntity replacedEntity) {
             super(totem);
-            this.oldEntity = oldEntity;
-            this.newVillager = newVillager;
-            this.replace = replace;
+            this.replacedEntity = replacedEntity;
+            this.originalNewVillagerType = newVillagerType;
+
         }
 
         /**
@@ -84,7 +85,21 @@ public abstract class FactionVillageEvent extends Event {
             return this.totem.getControllingFaction();
         }
 
-        public Villager getNewVillager() {
+        /**
+         * @return The type the ne
+         */
+        public EntityType<? extends Villager> getOriginalNewVillagerType(){
+            return originalNewVillagerType;
+        }
+
+        /**
+         * @return May be null, if entity creation fails
+         */
+        @Nullable
+        public Villager getOrCreateNewVillager(){
+            if(newVillager==null && getLevel() != null){
+                newVillager= getOriginalNewVillagerType().create(getLevel(), isReplace() ? EntitySpawnReason.CONVERSION : EntitySpawnReason.EVENT );
+            }
             return newVillager;
         }
 
@@ -97,18 +112,17 @@ public abstract class FactionVillageEvent extends Event {
         }
 
         /**
-         * A random existing villager which can be used as a seed (e.g. for the position)
+         * @return if the {@link #replacedEntity} will be replaced by {@link #newVillager}
          */
-        @Nullable
-        public LivingEntity getOldEntity() {
-            return oldEntity;
+        public boolean isReplace() {
+            return replacedEntity !=null;
         }
 
         /**
-         * @return if the {@link #oldEntity} will be replaced by {@link #newVillager}
+         * @return Villager to be replaced if present
          */
-        public boolean isReplace() {
-            return replace;
+        public Optional<LivingEntity> getEntityToReplace(){
+            return Optional.<LivingEntity>ofNullable(replacedEntity);
         }
 
     }
@@ -349,7 +363,11 @@ public abstract class FactionVillageEvent extends Event {
             return Collections.unmodifiableMap(this.entitiesScheduledForReplacement);
         }
 
+
         public enum Action {
+            /**
+             * Replace with a fresh villager
+             */
             REPLACE,
             KILL
         }

--- a/projects/faction/src/main/java/de/teamlapen/faction/common/event/FactionEventFactory.java
+++ b/projects/faction/src/main/java/de/teamlapen/faction/common/event/FactionEventFactory.java
@@ -15,6 +15,7 @@ import de.teamlapen.faction.api.factions.skills.ISkillPlayer;
 import de.teamlapen.faction.api.factions.skills.ISkillTree;
 import de.teamlapen.faction.api.world.ITotem;
 import net.minecraft.core.Holder;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.npc.villager.Villager;
 import net.minecraft.world.phys.AABB;
@@ -34,10 +35,10 @@ public class FactionEventFactory {
         return event.isEntityConversionDisabled();
     }
 
-    public static @NotNull Villager fireSpawnNewVillagerEvent(@NotNull ITotem totem, @Nullable LivingEntity oldEntity, @NotNull Villager newEntity, boolean replaceOld) {
-        FactionVillageEvent.SpawnNewVillager event = new FactionVillageEvent.SpawnNewVillager(totem, oldEntity, newEntity, replaceOld);
+    public static @Nullable Villager fireSpawnNewVillagerEvent(@NotNull ITotem totem, @NotNull EntityType<? extends Villager> newVillagerType, @Nullable LivingEntity replacedEntity) {
+        FactionVillageEvent.SpawnNewVillager event = new FactionVillageEvent.SpawnNewVillager(totem, newVillagerType, replacedEntity);
         NeoForge.EVENT_BUS.post(event);
-        return event.getNewVillager();
+        return event.getOrCreateNewVillager();
     }
 
     public static void fireMakeAggressive(@NotNull ITotem totem, @NotNull Villager entity) {

--- a/projects/faction/src/main/java/de/teamlapen/faction/common/world/blockentity/TotemBlockEntity.java
+++ b/projects/faction/src/main/java/de/teamlapen/faction/common/world/blockentity/TotemBlockEntity.java
@@ -478,8 +478,10 @@ public class TotemBlockEntity extends NetworkedBlockEntity implements ITotem {
             int villagerCount = this.level.getEntitiesOfClass(Villager.class, this.getVillageArea().inflate(20)).size();
             int max = Math.min(beds, FactionConfig.server().villageMaxSpawnableVillagers.get());
             if (villagerCount < max) {
-                var villager = FactionEventFactory.fireSpawnNewVillagerEvent(this, null, EntityType.VILLAGER.create(this.level, EntitySpawnReason.EVENT), false);
-                spawnEntity(villager);
+                var villager = FactionEventFactory.fireSpawnNewVillagerEvent(this, EntityType.VILLAGER, null);
+                if(villager!=null){
+                    spawnEntity(villager);
+                }
             } else {
                 spawnTaskMaster = true;
             }
@@ -828,9 +830,8 @@ public class TotemBlockEntity extends NetworkedBlockEntity implements ITotem {
                 if (action == FactionVillageEvent.UpdateCreaturesOnCaptureFinishEvent.Action.KILL) {
                     livingEntity.discard();
                 } else if (action == FactionVillageEvent.UpdateCreaturesOnCaptureFinishEvent.Action.REPLACE) {
-                    Villager villager = EntityType.VILLAGER.create(this.level, EntitySpawnReason.EVENT);
+                    Villager villager = FactionEventFactory.fireSpawnNewVillagerEvent(this, EntityType.VILLAGER, livingEntity);
                     if (villager == null) return;
-                    villager = FactionEventFactory.fireSpawnNewVillagerEvent(this, livingEntity, villager, fullConvert);
                     spawnEntity(villager, livingEntity);
                 }
             }));

--- a/projects/vampirism-api/src/main/java/de/teamlapen/vampirism/api/world/entity/convertible/ICurableConvertedCreature.java
+++ b/projects/vampirism-api/src/main/java/de/teamlapen/vampirism/api/world/entity/convertible/ICurableConvertedCreature.java
@@ -49,8 +49,8 @@ public interface ICurableConvertedCreature<T extends PathfinderMob> extends ICon
      * @param newType the entity type of the cured entity
      * @return the new entity
      */
-    default T createCuredEntity(@NotNull PathfinderMob entity, @NotNull EntityType<T> newType) {
-        T newEntity = newType.create(entity.level(), EntitySpawnReason.CONVERSION);
+    default T createCuredEntity(@NotNull PathfinderMob entity) {
+        T newEntity = getCuredEntityType().create(entity.level(), EntitySpawnReason.CONVERSION);
         assert newEntity != null;
         TagValueOutput output = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, entity.registryAccess());
         entity.saveWithoutId(output);
@@ -60,6 +60,12 @@ public interface ICurableConvertedCreature<T extends PathfinderMob> extends ICon
         newEntity.setUUID(UUID.randomUUID());
         return newEntity;
     }
+
+    /**
+     * @return The entity type this creature is cured to
+     */
+    @NotNull
+    EntityType<T> getCuredEntityType();
 
     /**
      * creates the cured entity and copies attributes <p>
@@ -72,8 +78,8 @@ public interface ICurableConvertedCreature<T extends PathfinderMob> extends ICon
      * @param newType the entity type of the cured entity
      * @return the new cured entity
      */
-    default T cureEntity(@NotNull ServerLevel world, @NotNull PathfinderMob entity, @NotNull EntityType<T> newType) {
-        T newEntity = createCuredEntity(entity, newType);
+    default T cureEntity(@NotNull ServerLevel world, @NotNull PathfinderMob entity) {
+        T newEntity = createCuredEntity(entity);
         entity.remove(Entity.RemovalReason.DISCARDED);
         entity.level().addFreshEntity(newEntity);
         newEntity.addEffect(new MobEffectInstance(MobEffects.NAUSEA, 200, 0));

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/VillageEventHandler.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/VillageEventHandler.java
@@ -5,6 +5,8 @@ import de.teamlapen.faction.api.factions.IFaction;
 import de.teamlapen.faction.api.world.ITotem;
 import de.teamlapen.faction.api.world.entities.ICaptureIgnore;
 import de.teamlapen.faction.common.util.SpawnUtil;
+import de.teamlapen.vampirism.api.world.entity.convertible.IConvertedCreature;
+import de.teamlapen.vampirism.api.world.entity.convertible.ICurableConvertedCreature;
 import de.teamlapen.vampirism.common.core.ModEffects;
 import de.teamlapen.vampirism.common.core.ModEntities;
 import de.teamlapen.vampirism.common.core.ModFactions;
@@ -25,6 +27,7 @@ import net.minecraft.util.random.WeightedList;
 import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.npc.villager.Villager;
 import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -69,19 +72,28 @@ public class VillageEventHandler {
 
     @SubscribeEvent
     public void onSpawnVillager(FactionVillageEvent.SpawnNewVillager event) {
-        if (IFaction.is(event.getFaction(), ModFactions.VAMPIRE)) {
-            if (event.getNewVillager().getRandom().nextBoolean()) {
-                var newVillager = event.setNewVillager(ModEntities.VILLAGER_CONVERTED.get().create(event.getLevel(), EntitySpawnReason.EVENT));
-                if (event.getOldEntity() instanceof Villager oldVillager) {
-                    newVillager.setHomeTo(oldVillager.getHomePosition(), oldVillager.getHomeRadius());
+        if(event.getLevel() != null){
+            if (IFaction.is(event.getFaction(), ModFactions.VAMPIRE)) {
+                if(event.getLevel().getRandom().nextBoolean()){
+                    var newVillager = ModEntities.VILLAGER_CONVERTED.get().create(event.getLevel(), EntitySpawnReason.EVENT);
+                    if(newVillager != null) {
+                        event.setNewVillager(newVillager);
+                    }
+                }
+            } else if (IFaction.is(event.getFaction(), ModFactions.HUNTER)) {
+                //If the previous creature is curable -> cure it instead of replacing it with a new villager
+                PathfinderMob newVillager = event.getEntityToReplace().map(old -> {
+                        if(old instanceof Villager villager && old instanceof ICurableConvertedCreature<?> curable){
+                            return curable.createCuredEntity(villager);
+                        }
+                        return event.getOrCreateNewVillager();
+                }).orElseGet(event::getOrCreateNewVillager);
+                if(newVillager != null) {
+                    ExtendedCreature.getSafe(newVillager).ifPresent(x -> x.setPoisonousBlood(ExtendedCreature.POISONOUS_BLOOD_DOSE_DURATION));
                 }
             }
-        } else if (IFaction.is(event.getFaction(), ModFactions.HUNTER)) {
-            ExtendedCreature.getSafe(event.getNewVillager()).ifPresent(x -> x.setPoisonousBlood(ExtendedCreature.POISONOUS_BLOOD_DOSE_DURATION));
-            if (event.getOldEntity() instanceof Villager oldVillager) {
-                event.getNewVillager().setHomeTo(oldVillager.getHomePosition(), oldVillager.getHomeRadius());
-            }
         }
+
     }
 
     @SubscribeEvent
@@ -128,7 +140,7 @@ public class VillageEventHandler {
                 if (villagerEntity.hasEffect(ModEffects.SANGUINARE)) {
                     villagerEntity.removeEffect(ModEffects.SANGUINARE);
                 }
-                if (event.isForced() && villagerEntity instanceof ConvertedVillagerEntity) {
+                if (event.isForced() && villagerEntity instanceof IConvertedCreature<?>) {
                     event.requestReplacement(villagerEntity);
                 }
             }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCamelEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCamelEntity.java
@@ -50,6 +50,11 @@ public class ConvertedCamelEntity extends Camel implements CurableConvertedCreat
     }
 
     @Override
+    public @NotNull EntityType<Camel> getCuredEntityType() {
+        return EntityType.CAMEL;
+    }
+
+    @Override
     public Data<Camel> data() {
         return this.data;
     }
@@ -78,7 +83,7 @@ public class ConvertedCamelEntity extends Camel implements CurableConvertedCreat
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.CAMEL);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCatEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCatEntity.java
@@ -45,6 +45,11 @@ public class ConvertedCatEntity extends Cat implements CurableConvertedCreature<
     }
 
     @Override
+    public @NotNull EntityType<Cat> getCuredEntityType() {
+        return EntityType.CAT;
+    }
+
+    @Override
     public @NotNull EntityDataAccessor<Boolean> getConvertingDataParam() {
         return CONVERTING;
     }
@@ -83,7 +88,7 @@ public class ConvertedCatEntity extends Cat implements CurableConvertedCreature<
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.CAT);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCowEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCowEntity.java
@@ -46,6 +46,11 @@ public class ConvertedCowEntity extends Cow implements CurableConvertedCreature<
     }
 
     @Override
+    public @NotNull EntityType<Cow> getCuredEntityType() {
+        return EntityType.COW;
+    }
+
+    @Override
     public @NotNull EntityDataAccessor<Boolean> getConvertingDataParam() {
         return CONVERTING;
     }
@@ -84,7 +89,7 @@ public class ConvertedCowEntity extends Cow implements CurableConvertedCreature<
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.COW);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCreatureEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedCreatureEntity.java
@@ -97,7 +97,7 @@ public class ConvertedCreatureEntity<T extends PathfinderMob> extends VampireBas
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
             //noinspection unchecked
-            this.entityCreature.ifPresent(creature -> aiStepC(serverLevel, (EntityType<T>) creature.getType()));
+            this.entityCreature.ifPresent(creature -> aiStepC(serverLevel));
         }
         super.aiStep();
     }
@@ -152,11 +152,19 @@ public class ConvertedCreatureEntity<T extends PathfinderMob> extends VampireBas
     }
 
     @Override
-    public T cureEntity(@NotNull ServerLevel world, @NotNull PathfinderMob entity, @NotNull EntityType<T> newType) {
+    public T cureEntity(@NotNull ServerLevel world, @NotNull PathfinderMob entity) {
         return this.entityCreature.map(creature -> {
             creature.revive();
             return creature;
-        }).orElseGet(() -> CurableConvertedCreature.super.cureEntity(world, entity, newType));
+        }).orElseGet(() -> CurableConvertedCreature.super.cureEntity(world, entity));
+    }
+
+    @Override
+    public @NotNull EntityType<T> getCuredEntityType() {
+        return this.entityCreature.map(creature -> (EntityType<T>) creature.getType()).orElseGet( ()->{
+            LOGGER.warn("Trying to cure a ConvertedCreatureEntity with an empty wrapped entityCreature. Returning dummy entity. Might cause problems.");
+            return (EntityType<T>) (this.getType());
+        });
     }
 
     @Override

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedDonkeyEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedDonkeyEntity.java
@@ -49,6 +49,11 @@ public class ConvertedDonkeyEntity extends Donkey implements CurableConvertedCre
     }
 
     @Override
+    public @NotNull EntityType<Donkey> getCuredEntityType() {
+        return EntityType.DONKEY;
+    }
+
+    @Override
     public Data<Donkey> data() {
         return this.data;
     }
@@ -77,7 +82,7 @@ public class ConvertedDonkeyEntity extends Donkey implements CurableConvertedCre
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.DONKEY);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedFoxEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedFoxEntity.java
@@ -45,6 +45,11 @@ public class ConvertedFoxEntity extends Fox implements CurableConvertedCreature<
     }
 
     @Override
+    public @NotNull EntityType<Fox> getCuredEntityType() {
+        return EntityType.FOX;
+    }
+
+    @Override
     public @NotNull EntityDataAccessor<Boolean> getConvertingDataParam() {
         return CONVERTING;
     }
@@ -83,7 +88,7 @@ public class ConvertedFoxEntity extends Fox implements CurableConvertedCreature<
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.FOX);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedGoatEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedGoatEntity.java
@@ -45,6 +45,11 @@ public class ConvertedGoatEntity extends Goat implements CurableConvertedCreatur
     }
 
     @Override
+    public @NotNull EntityType<Goat> getCuredEntityType() {
+        return EntityType.GOAT;
+    }
+
+    @Override
     public @NotNull EntityDataAccessor<Boolean> getConvertingDataParam() {
         return CONVERTING;
     }
@@ -83,7 +88,7 @@ public class ConvertedGoatEntity extends Goat implements CurableConvertedCreatur
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.GOAT);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedHorseEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedHorseEntity.java
@@ -50,6 +50,11 @@ public class ConvertedHorseEntity extends Horse implements CurableConvertedCreat
     }
 
     @Override
+    public @NotNull EntityType<Horse> getCuredEntityType() {
+        return EntityType.HORSE;
+    }
+
+    @Override
     public Data<Horse> data() {
         return this.data;
     }
@@ -78,7 +83,7 @@ public class ConvertedHorseEntity extends Horse implements CurableConvertedCreat
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.HORSE);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedMuleEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedMuleEntity.java
@@ -49,6 +49,11 @@ public class ConvertedMuleEntity extends Mule implements CurableConvertedCreatur
     }
 
     @Override
+    public @NotNull EntityType<Mule> getCuredEntityType() {
+        return EntityType.MULE;
+    }
+
+    @Override
     public Data<Mule> data() {
         return this.data;
     }
@@ -77,7 +82,7 @@ public class ConvertedMuleEntity extends Mule implements CurableConvertedCreatur
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.MULE);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedSheepEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedSheepEntity.java
@@ -46,6 +46,11 @@ public class ConvertedSheepEntity extends Sheep implements CurableConvertedCreat
     }
 
     @Override
+    public @NotNull EntityType<Sheep> getCuredEntityType() {
+        return EntityType.SHEEP;
+    }
+
+    @Override
     public @NotNull EntityDataAccessor<Boolean> getConvertingDataParam() {
         return CONVERTING;
     }
@@ -84,7 +89,7 @@ public class ConvertedSheepEntity extends Sheep implements CurableConvertedCreat
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.SHEEP);
+            aiStepC(serverLevel);
         }
         super.aiStep();
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedVillagerEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/ConvertedVillagerEntity.java
@@ -85,6 +85,11 @@ public class ConvertedVillagerEntity extends VampirismVillagerEntity implements 
     }
 
     @Override
+    public @NotNull EntityType<Villager> getCuredEntityType() {
+        return EntityType.VILLAGER;
+    }
+
+    @Override
     public float getCaptureStrength() {
         return 0.5f;
     }
@@ -98,7 +103,7 @@ public class ConvertedVillagerEntity extends VampirismVillagerEntity implements 
     @Override
     public void aiStep() {
         if (this.level() instanceof ServerLevel serverLevel) {
-            aiStepC(serverLevel, EntityType.VILLAGER);
+            aiStepC(serverLevel);
         }
         bloodTimer++;
         super.aiStep();
@@ -120,8 +125,8 @@ public class ConvertedVillagerEntity extends VampirismVillagerEntity implements 
     }
 
     @Override
-    public @NotNull Villager cureEntity(@NotNull ServerLevel world, @NotNull PathfinderMob entity, @NotNull EntityType<Villager> newType) {
-        Villager villager = CurableConvertedCreature.super.cureEntity(world, entity, newType);
+    public @NotNull Villager cureEntity(@NotNull ServerLevel world, @NotNull PathfinderMob entity) {
+        Villager villager = CurableConvertedCreature.super.cureEntity(world, entity);
         if (this.data().conversationStarter != null) {
             Player playerentity = world.getPlayerByUUID(this.data().conversationStarter);
             if (playerentity instanceof ServerPlayer) {

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/CurableConvertedCreature.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/converted/CurableConvertedCreature.java
@@ -144,12 +144,12 @@ public interface CurableConvertedCreature<T extends PathfinderMob, Z extends Pat
     /**
      * call in {@link PathfinderMob#aiStep()}
      */
-    default void aiStepC(ServerLevel level, @NotNull EntityType<T> originalType) {
+    default void aiStepC(ServerLevel level) {
         PathfinderMob entity = ((PathfinderMob) this);
         if (entity.isAlive() && this.isConverting(entity)) {
             --data().conversionTime;
-            if (data().conversionTime <= 0 && net.neoforged.neoforge.event.EventHooks.canLivingConvert(entity, originalType, (timer) -> data().conversionTime = timer)) {
-                this.cureEntity((ServerLevel) entity.level(), entity, originalType);
+            if (data().conversionTime <= 0 && net.neoforged.neoforge.event.EventHooks.canLivingConvert(entity, getCuredEntityType(), (timer) -> data().conversionTime = timer)) {
+                this.cureEntity((ServerLevel) entity.level(), entity);
             }
         }
         if (entity.tickCount % REFERENCE.REFRESH_GARLIC_TICKS == 1) {


### PR DESCRIPTION
Rework Villager Spawn events for faction villages.
- Don't create creatures instances that may be discarded anyway
- Vampire villagers may be cured instead of replaced by a new villager
- Better support for future MCA integration

ICurableConvertedCreature implementations must now provide the cured EntityType.
I don't see a clear reason for always passing the EntityType to the "curing" methods. This type should always be decided by the class itself and may not be known by external classes. By removing this argument, it is also possible to externally use these methods. 

<s>I have not yet been able to test this due to several pre-existing bugs:
- The vampire player action menu does not open (client side error is thrown)
- Vanilla golems seem to attack every creature (even cows) regardless of village faction
- The converted villagers don't have a (rendered) overlay</s>

I will try to investigate these issues first.
