### PR TITLE
Changed resistance effect for batmode onDeactivated

### DIFF
--- a/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/BatVampireAction.java
+++ b/src/main/java/de/teamlapen/vampirism/entity/player/vampire/actions/BatVampireAction.java
@@ -94,7 +94,7 @@ public class BatVampireAction extends DefaultVampireAction implements ILastingAc
         Player player = vampire.asEntity();
         setModifier(player, false);
         if (!player.onGround()) {
-            player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 20, 100, false, false));
+            player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 20, 5, false, false));
         }
         //player.addPotionEffect(new PotionEffect(MobEffects.REGENERATION, 20, 0, false, false));
         updatePlayer((VampirePlayer) vampire, false);


### PR DESCRIPTION
from resistance lvl 101 to lvl 6
This change was made to deal with hybrid servers, namely Youer and Arclights, having a resistance bug of having taking damage and protection enchants amplifying said damage to the point of players dying.