### PR TITLE
Tooltip Fixes

### DIFF
--- a/projects/faction/src/main/java/de/teamlapen/faction/client/DescriptionTooltips.java
+++ b/projects/faction/src/main/java/de/teamlapen/faction/client/DescriptionTooltips.java
@@ -19,7 +19,7 @@ public class DescriptionTooltips {
         }
 
         if (orDefault.shows(FactionDataComponents.SHIFT_DESCRIPTION.get()) && event.getItemStack().get(FactionDataComponents.SHIFT_DESCRIPTION) instanceof ShiftDescription shiftDescription) {
-            shiftDescription.addTooltips(event.getItemStack(), event.getEntity(), event.getContext(), event.getFlags(), event.getToolTip()::add);
+            shiftDescription.addTooltips(event.getItemStack(), event.getEntity(), event.getContext(), event.getFlags(), event.getToolTip());
         }
     }
 }

--- a/projects/faction/src/main/java/de/teamlapen/faction/common/components/FactionRestriction.java
+++ b/projects/faction/src/main/java/de/teamlapen/faction/common/components/FactionRestriction.java
@@ -216,8 +216,10 @@ public record FactionRestriction(HolderSet<IFaction<?>> factions, Optional<Holde
             tooltips.accept(Component.translatable("tooltip.factionapi.required_skills").withStyle(ChatFormatting.GRAY));
 
             skills.forEach(skill -> tooltips.accept(Component.literal(" ").append(skill.value().getName().withStyle(style -> {
-                if (skillHandler == null) return style;
-                return skillHandler.isSkillEnabled(skill) ? style.withColor(ChatFormatting.DARK_GREEN) : style.withColor(ChatFormatting.DARK_RED);
+                if (skillHandler != null && skillHandler.isSkillEnabled(skill)) {
+                    return style.withColor(ChatFormatting.DARK_GREEN);
+                }
+                return style.withColor(ChatFormatting.DARK_RED);
             }))));
         }
     }

--- a/projects/faction/src/main/java/de/teamlapen/faction/common/util/DescriptionUtil.java
+++ b/projects/faction/src/main/java/de/teamlapen/faction/common/util/DescriptionUtil.java
@@ -10,12 +10,15 @@ import net.minecraft.world.item.TooltipFlag;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 public class DescriptionUtil {
 
-    public static void addDescriptionTooltip(Component component, Item.TooltipContext context, TooltipFlag tooltipFlag, Consumer<Component> tooltipComponents) {
-        tooltipComponents.accept(Component.translatable("tooltip.factionapi.hold_shift_for_info", FactionKeys.ITEM_DESCRIPTION.getTranslatedKeyMessage().copy().withStyle(ChatFormatting.GRAY)).withStyle(ChatFormatting.DARK_GRAY));
+    public static void addDescriptionTooltip(Component component, Item.TooltipContext context, TooltipFlag tooltipFlag, List<Component> tooltipComponents) {
+        if (tooltipComponents.size() > 2) {
+            tooltipComponents.add(Component.empty());
+        }
+
+        tooltipComponents.add(Component.translatable("tooltip.factionapi.hold_shift_for_info", FactionKeys.ITEM_DESCRIPTION.getTranslatedKeyMessage().copy().withStyle(ChatFormatting.GRAY)).withStyle(ChatFormatting.DARK_GRAY));
 
         int keyCode = FactionKeys.ITEM_DESCRIPTION.getKey().getValue();
         boolean isHeld = InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), keyCode);
@@ -23,9 +26,9 @@ public class DescriptionUtil {
         if (isHeld) {
             List<String> lines = normalizeTextWidth(component.getString(), 40);
 
-            tooltipComponents.accept(Component.empty());
+            tooltipComponents.add(Component.empty());
             for (String line : lines) {
-                tooltipComponents.accept(Component.literal(line).withStyle(ChatFormatting.GRAY));
+                tooltipComponents.add(Component.literal(line).withStyle(ChatFormatting.GRAY));
             }
         }
     }

--- a/projects/faction/src/main/java/de/teamlapen/faction/common/util/ShiftDescription.java
+++ b/projects/faction/src/main/java/de/teamlapen/faction/common/util/ShiftDescription.java
@@ -15,8 +15,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 public record ShiftDescription(@Nullable Component component, @Nullable String formatableString) {
 
@@ -48,7 +48,7 @@ public record ShiftDescription(@Nullable Component component, @Nullable String f
         return new ShiftDescription((Component) null, null);
     }
 
-    public void addTooltips(ItemStack stack, @Nullable Player player, Item.TooltipContext context, TooltipFlag tooltipFlag, Consumer<Component> tooltipAdder) {
+    public void addTooltips(ItemStack stack, @Nullable Player player, Item.TooltipContext context, TooltipFlag tooltipFlag, List<Component> tooltipComponents) {
         var component = this.component;
         if (component == null) {
             component = Optional.ofNullable(this.formatableString).or(() -> stack.typeHolder().unwrapKey().map(x -> x.identifier().toLanguageKey("tooltip"))).map(x -> {
@@ -61,7 +61,7 @@ public record ShiftDescription(@Nullable Component component, @Nullable String f
             }).orElse(Component.empty());
         }
 
-        DescriptionUtil.addDescriptionTooltip(component, context, tooltipFlag, tooltipAdder);
+        DescriptionUtil.addDescriptionTooltip(component, context, tooltipFlag, tooltipComponents);
     }
 
     @Nullable

--- a/projects/vampirism/src/integrations/guide/java/de/teamlapen/vampirism/common/integration/guide/GuideBook.java
+++ b/projects/vampirism/src/integrations/guide/java/de/teamlapen/vampirism/common/integration/guide/GuideBook.java
@@ -44,6 +44,7 @@ import de.teamlapen.vampirism.common.world.items.BloodBottleItem;
 import de.teamlapen.vampirism.common.world.items.recipes.AlchemicalCauldronRecipe;
 import de.teamlapen.vampirism.common.world.items.recipes.ShapedWeaponTableRecipe;
 import de.teamlapen.vampirism.common.world.items.recipes.ShapelessWeaponTableRecipe;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
@@ -663,7 +664,7 @@ public class GuideBook implements IGuideBook {
         binder.setGuideTitleKey("guide.vampirism.title");
         binder.setItemNameKey("guide.vampirism");
         binder.setHeaderKey("guide.vampirism.welcome");
-        binder.setAuthor(Component.literal("Maxanier"));
+        binder.setAuthor(Component.translatable("book.byAuthor", "Maxanier").withStyle(ChatFormatting.GRAY));
         binder.setThemeColor(Color.WHITE.getRGB());
         binder.setOutlineTexture(Identifier.fromNamespaceAndPath("vampirismguide", "textures/gui/book_violet_border.png"));
         binder.setSpawnWithBook();

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/core/ModItems.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/core/ModItems.java
@@ -516,6 +516,6 @@ public class ModItems {
     }
 
     private static DeferredItem<CoffinItem> fromCoffin(DeferredHolder<Block, CoffinBlock> block) {
-        return fromBlock(block, (block1, itemProps) -> new CoffinItem((CoffinBlock) block1, itemProps.factions$withShiftDescription().rarity(Rarity.RARE).stacksTo(1).useBlockDescriptionPrefix()));
+        return fromBlock(block, (block1, itemProps) -> new CoffinItem((CoffinBlock) block1, itemProps.rarity(Rarity.RARE).stacksTo(1).useBlockDescriptionPrefix()));
     }
 }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/core/ModItems.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/core/ModItems.java
@@ -212,12 +212,7 @@ public class ModItems {
 
     public static final DeferredItem<Item> PURIFIED_GARLIC = ITEMS.registerItem("purified_garlic",  Item::new, props -> props.stacksTo(16));
     public static final DeferredItem<Item> PURE_SALT = ITEMS.registerItem("pure_salt", Item::new);
-    public static final DeferredItem<BlessableItem> PURE_SALT_WATER = ITEMS.registerItem("pure_salt_water",  props -> new BlessableItem(props.stacksTo(1), HOLY_WATER_BOTTLE_NORMAL, HOLY_WATER_BOTTLE_ENHANCED) {
-        @Override
-        public boolean isFoil(ItemStack stack) {
-            return true;
-        }
-    });
+    public static final DeferredItem<BlessableItem> PURE_SALT_WATER = ITEMS.registerItem("pure_salt_water",  props -> new BlessableItem(props.stacksTo(1).component(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true), HOLY_WATER_BOTTLE_NORMAL, HOLY_WATER_BOTTLE_ENHANCED));
 
     public static final DeferredItem<Item> SOUL_ORB_VAMPIRE = ITEMS.registerItem("soul_orb_vampire", Item::new);
     public static final DeferredItem<Item> MOTHER_CORE = ITEMS.registerItem("mother_core",  Item::new, props -> props.rarity(Rarity.UNCOMMON));

--- a/projects/vampirism/src/main/resources/assets/vampirism/lang/en_us.json
+++ b/projects/vampirism/src/main/resources/assets/vampirism/lang/en_us.json
@@ -580,7 +580,7 @@
   "skill.vampirism.water_resistance.desc": "No longer be weakened by water",
   "skill.vampirism.less_blood_thirst": "Frugal Vampire",
   "skill.vampirism.less_blood_thirst.desc": "Reduce your passive blood consumption",
-  "skill.vampirism.vampire_lord": "Become a Vampire Lord",
+  "skill.vampirism.vampire_lord": "Becoming a Vampire Lord",
   "skill.vampirism.vampire_minion_stats_increase": "Better Minions",
   "skill.vampirism.vampire_minion_stats_increase.desc": "Improve the stats of your minions",
   "skill.vampirism.vampire_minion_collect": "Blood Collection",
@@ -653,7 +653,7 @@
   "skill.vampirism.vampire_dracula": "Becoming Dracula",
   "skill.vampirism.vampire_dracula.desc": "You are now Dracula, with wings",
   "skill.vampirism.wander_the_sun": "Wander the Sun",
-  "skill.vampirism.wander_the_sun.desc": "You no longer receive damage from the sun",
+  "skill.vampirism.wander_the_sun.desc": "No longer receive damage from the sun",
 
   "advancement.vampirism": "Vampirism",
   "advancement.vampirism.desc": "Getting started with Vampirism",

--- a/projects/vampirism/src/main/resources/assets/vampirism/lang/en_us.json
+++ b/projects/vampirism/src/main/resources/assets/vampirism/lang/en_us.json
@@ -641,7 +641,7 @@
   "skill.vampirism.axe2.desc": "Cause vampires to bleed when struck with a hunter axe",
   "skill.vampirism.artisan_craftsmanship": "Artisan Craftsmanship",
   "skill.vampirism.artisan_craftsmanship.desc": "Craft and equip ultimate weapons and armor",
-  "skill.vampirism.hunter_lord": "Become a Hunter Lord",
+  "skill.vampirism.hunter_lord": "Becoming a Hunter Lord",
   "skill.vampirism.hunter_minion_stats_increase": "Better Minions",
   "skill.vampirism.hunter_minion_stats_increase.desc": "Improve the stats of your minions",
   "skill.vampirism.minion_tech_crossbows": "Technology",


### PR DESCRIPTION
This pull request mainly consists of simple tooltip fixes and adjustments.

- Missing skills in item descriptions (those below "Faction Specifics") are now always marked red. Those were white if the player was of the wrong faction.

<img width="469" height="365" alt="Screenshot 2026-07-22 at 22 52 10" src="https://github.com/user-attachments/assets/a68f623e-b10b-4416-9705-eb9f7be75371" />

- There shift descriptions now come after an extra space after tooltips that consist of more than 2 lines (including the "Vampirism" slag below the item). So items with no other tooltips are short, but those that are already long (especially the branching ones like the level-requiring one) receive spacing to look cleaner.

<img width="554" height="224" alt="Screenshot 2026-07-22 at 22 48 41" src="https://github.com/user-attachments/assets/80a68c6c-8a79-4772-b2d0-c582da22050c" /> <img width="490" height="286" alt="Screenshot 2026-07-22 at 22 48 49" src="https://github.com/user-attachments/assets/e41f6216-92d3-40dc-8355-18c715d17fac" />

- Coffins no longer have empty shift descriptions.

- The Vampirism guidebook item now has "by" before Maxanier's name. The tooltip color is also light gray. This looks a bit cleaner.

<img width="365" height="182" alt="Screenshot 2026-07-22 at 23 01 45" src="https://github.com/user-attachments/assets/ab50f0a4-4346-4e91-97e2-5086c40d77cd" />

- The following skill names/descriptions were corrected:

"Become a Vampire Lord" is now "Becoming a Vampire Lord" to match other similar skills. Same for the hunter one.

"You no longer receive damage from the sun" is now "No longer receive damage from the sun" to correspond with the rest of the skill descriptions. This is a new skill added with Dracula, so it might not have the same phrasing logic as the existing ones.

- The pure salt water item now uses a data component to mart itself as foil instead of a method right in the ModItems class.