### PR TITLE
use holder for supporter book (with empty fallback)

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="Vampirism Supporters">
+          <value>
+            <SchemaInfo>
+              <option name="generatedName" value="New Schema" />
+              <option name="name" value="Vampirism Supporters" />
+              <option name="relativePathToSchema" value="schemas/supporters.schema.json" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="projects/vampirism/src/main/resources/supporters.json" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="Vampirism Wings">
+          <value>
+            <SchemaInfo>
+              <option name="generatedName" value="New Schema" />
+              <option name="name" value="Vampirism Wings" />
+              <option name="relativePathToSchema" value="schemas/wings.schema.json" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="projects/vampirism/src/main/resources/wings.json" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>

--- a/projects/vampirism-api/src/main/java/de/teamlapen/vampirism/api/world/entity/VampireBookLootProvider.java
+++ b/projects/vampirism-api/src/main/java/de/teamlapen/vampirism/api/world/entity/VampireBookLootProvider.java
@@ -1,5 +1,7 @@
 package de.teamlapen.vampirism.api.world.entity;
 
+import de.teamlapen.vampirism.api.world.items.components.IVampireBook;
+import net.minecraft.core.Holder;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
@@ -7,5 +9,5 @@ import java.util.Optional;
 public interface VampireBookLootProvider {
 
     @NotNull
-    Optional<String> getBookLootId();
+    Optional<Holder<IVampireBook>> getBookLootId();
 }

--- a/projects/vampirism-api/src/main/java/de/teamlapen/vampirism/api/world/items/components/IVampireBook.java
+++ b/projects/vampirism-api/src/main/java/de/teamlapen/vampirism/api/world/items/components/IVampireBook.java
@@ -1,11 +1,18 @@
 package de.teamlapen.vampirism.api.world.items.components;
 
+import com.mojang.serialization.Codec;
+import de.teamlapen.vampirism.api.VampirismRegistries;
 import de.teamlapen.vampirism.api.general.IBookBackground;
 import de.teamlapen.vampirism.api.general.IBookContents;
+import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.RegistryFixedCodec;
 import net.minecraft.tags.TagKey;
 
 import java.util.List;
@@ -14,6 +21,10 @@ import java.util.List;
  * A component that stores vampire book data, its id and author.
  */
 public interface IVampireBook {
+
+    Codec<Holder<IVampireBook>> HOLDER_CODEC = RegistryFixedCodec.create(VampirismRegistries.Keys.VAMPIRE_BOOK);
+
+    StreamCodec<RegistryFriendlyByteBuf, Holder<IVampireBook>> HOLDER_STREAM_CODEC = ByteBufCodecs.holderRegistry(VampirismRegistries.Keys.VAMPIRE_BOOK);
 
     /**
      * The id of the book.

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/CommonServices.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/CommonServices.java
@@ -108,7 +108,6 @@ public class CommonServices extends Services implements IVampirismServices {
         bus.addListener(this.versionUpdater::catchModVersionMismatch);
         bus.addListener(FMLCommonSetupEvent.class, e -> e.enqueueWork(ModEntitySelectors::registerSelectors));
         bus.addListener(FMLLoadCompleteEvent.class, e -> e.enqueueWork(OverworldModifications::addBiomesToOverworldUnsafe));
-        bus.addListener(FMLCommonSetupEvent.class, _ -> this.supporterManager.init());
         bus.addListener(InterModProcessEvent.class, _ -> QuarrelHandler.collectQuarrels());
         bus.addListener(AddFactionTagEvent.class, ModFactions::registerFactionTags);
         bus.addListener(ModCreativeTabs::addToExistingCreativeTabs);
@@ -129,6 +128,7 @@ public class CommonServices extends Services implements IVampirismServices {
         bus.register(this.villageEventHandler);
         bus.addListener(Permissions::registerNodes);
         bus.register(this.itemEventHandler);
+        bus.register(this.supporterManager);
         bus.addListener(DefaultDataComponentsBoundEvent.class, _ -> QuarrelHandler.collectClips());
         bus.register(this.levelEventHandler);
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/PlayerSkinHelper.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/PlayerSkinHelper.java
@@ -14,7 +14,9 @@ import net.minecraft.world.item.component.ResolvableProfile;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.client.event.ClientResourceLoadFinishedEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
+import org.jetbrains.annotations.UnmodifiableView;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -26,10 +28,9 @@ public class PlayerSkinHelper {
     private final Map<String, PlayerSkin> skinsReadonly = Collections.unmodifiableMap(skins);
     private final Map<String, PlayerSkin> remoteSkins = new HashMap<>();
 
-    @SubscribeEvent
-    public void onLoadLevel(LevelEvent.Load event) {
-    }
-
+    /**
+     * Load required resources when resources changes
+     */
     @SubscribeEvent
     public void onResourcesLoad(ClientResourceLoadFinishedEvent event) {
         var skins = loadBuiltInSkins();
@@ -38,6 +39,15 @@ public class PlayerSkinHelper {
         this.skins.putAll(skins);
     }
 
+    /**
+     * Reload missing textures after supporters are loaded
+     */
+    @SubscribeEvent
+    public void onLevelLoad(LevelEvent.Load event) {
+        checkMissingSkins(skins);
+    }
+
+    @UnmodifiableView
     public Map<String, PlayerSkin> getSkins() {
         return this.skinsReadonly;
     }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/SupporterManager.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/SupporterManager.java
@@ -1,5 +1,6 @@
 package de.teamlapen.vampirism.common.util;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
@@ -7,12 +8,18 @@ import com.mojang.serialization.JsonOps;
 import de.teamlapen.vampirism.VampirismMod;
 import de.teamlapen.vampirism.api.VReference;
 import de.teamlapen.vampirism.common.util.supporter.Supporter;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.util.RandomSource;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.HashMap;
@@ -48,13 +55,22 @@ public class SupporterManager {
         return Supporter.FALLBACK;
     }
 
-    public void init() {
+    /**
+     * Load supporter when we have access to the registries
+     */
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void onLoadLevel(LevelEvent.Load event) {
+        loadSupporter(event.getLevel().registryAccess());
+    }
+
+    public void loadSupporter(RegistryAccess registryAccess) {
         InputStream inputStream = VampirismMod.class.getResourceAsStream("/supporters.json");
         if (inputStream != null) {
-            try {
-                JsonReader jsonReader = new JsonReader(new InputStreamReader(inputStream));
-                this.supporters = Supporter.CODEC.codec().listOf().parse(JsonOps.INSTANCE, JsonParser.parseReader(jsonReader)).getPartialOrThrow().stream().collect(Collectors.groupingBy(Supporter::faction));
-            } catch (JsonSyntaxException ex) {
+            JsonReader jsonReader = new JsonReader(new InputStreamReader(inputStream));
+            try (jsonReader) {
+                var ops = RegistryOps.create(JsonOps.INSTANCE, registryAccess);
+                this.supporters = Supporter.CODEC.codec().listOf().parse(ops, JsonParser.parseReader(jsonReader)).getPartialOrThrow().stream().collect(Collectors.groupingBy(Supporter::faction));
+            } catch (JsonSyntaxException | IOException ex) {
                 LOGGER.error("Failed to retrieve supporter from file", ex);
             }
         }

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/supporter/Supporter.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/supporter/Supporter.java
@@ -4,6 +4,8 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import de.teamlapen.faction.api.Factions;
+import de.teamlapen.vampirism.api.world.items.components.IVampireBook;
+import net.minecraft.core.Holder;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentSerialization;
@@ -16,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public record Supporter(Identifier faction, Component name, String player, Map<String, String> appearance, Optional<String> bookId) {
+public record Supporter(Identifier faction, Component name, String player, Map<String, String> appearance, Optional<Holder<IVampireBook>> bookId) {
 
     public static final Supporter FALLBACK = new Supporter(Factions.Keys.NEUTRAL, Component.empty(), "", Map.of(), Optional.empty());
 
@@ -25,7 +27,7 @@ public record Supporter(Identifier faction, Component name, String player, Map<S
             ComponentSerialization.CODEC.fieldOf("name").forGetter(Supporter::name),
             Codec.STRING.fieldOf("player").forGetter(Supporter::player),
             Codec.unboundedMap(Codec.STRING, Codec.STRING).fieldOf("appearance").forGetter(Supporter::appearance),
-            Codec.STRING.optionalFieldOf("bookId").forGetter(Supporter::bookId)
+            IVampireBook.HOLDER_CODEC.optionalFieldOf("bookId").orElse(Optional.empty()).forGetter(Supporter::bookId)
     ).apply(inst, Supporter::new));
 
     public static final StreamCodec<RegistryFriendlyByteBuf, Supporter> STREAM_CODEC = StreamCodec.composite(
@@ -33,7 +35,7 @@ public record Supporter(Identifier faction, Component name, String player, Map<S
             ComponentSerialization.STREAM_CODEC, Supporter::name,
             ByteBufCodecs.STRING_UTF8, Supporter::player,
             ByteBufCodecs.map(HashMap::new, ByteBufCodecs.STRING_UTF8, ByteBufCodecs.STRING_UTF8), Supporter::appearance,
-            ByteBufCodecs.optional(ByteBufCodecs.STRING_UTF8), Supporter::bookId,
+            ByteBufCodecs.optional(IVampireBook.HOLDER_STREAM_CODEC), Supporter::bookId,
             Supporter::new
     );
 

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/supporter/Supporter.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/util/supporter/Supporter.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public record Supporter(Identifier faction, Component name, String player, Map<String, String> appearance, Optional<Holder<IVampireBook>> bookId) {
+public record Supporter(Identifier faction, Component name, String player, Map<String, String> appearance, Optional<Holder<IVampireBook>> book) {
 
     public static final Supporter FALLBACK = new Supporter(Factions.Keys.NEUTRAL, Component.empty(), "", Map.of(), Optional.empty());
 
@@ -27,7 +27,7 @@ public record Supporter(Identifier faction, Component name, String player, Map<S
             ComponentSerialization.CODEC.fieldOf("name").forGetter(Supporter::name),
             Codec.STRING.fieldOf("player").forGetter(Supporter::player),
             Codec.unboundedMap(Codec.STRING, Codec.STRING).fieldOf("appearance").forGetter(Supporter::appearance),
-            IVampireBook.HOLDER_CODEC.optionalFieldOf("bookId").orElse(Optional.empty()).forGetter(Supporter::bookId)
+            IVampireBook.HOLDER_CODEC.optionalFieldOf("book").orElse(Optional.empty()).forGetter(Supporter::book)
     ).apply(inst, Supporter::new));
 
     public static final StreamCodec<RegistryFriendlyByteBuf, Supporter> STREAM_CODEC = StreamCodec.composite(
@@ -35,7 +35,7 @@ public record Supporter(Identifier faction, Component name, String player, Map<S
             ComponentSerialization.STREAM_CODEC, Supporter::name,
             ByteBufCodecs.STRING_UTF8, Supporter::player,
             ByteBufCodecs.map(HashMap::new, ByteBufCodecs.STRING_UTF8, ByteBufCodecs.STRING_UTF8), Supporter::appearance,
-            ByteBufCodecs.optional(IVampireBook.HOLDER_STREAM_CODEC), Supporter::bookId,
+            ByteBufCodecs.optional(IVampireBook.HOLDER_STREAM_CODEC), Supporter::book,
             Supporter::new
     );
 

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/hunter/AdvancedHunterEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/hunter/AdvancedHunterEntity.java
@@ -14,7 +14,6 @@ import de.teamlapen.vampirism.common.core.ModAttachments;
 import de.teamlapen.vampirism.common.core.ModEntities;
 import de.teamlapen.vampirism.common.core.ModItems;
 import de.teamlapen.vampirism.common.util.UtilLib;
-import de.teamlapen.vampirism.common.util.supporter.Supporter;
 import de.teamlapen.vampirism.common.world.entity.ISupporterAppearanceConsumer;
 import de.teamlapen.vampirism.common.world.entity.VampirismEntity;
 import de.teamlapen.vampirism.common.world.entity.ai.goals.*;
@@ -118,7 +117,7 @@ public class AdvancedHunterEntity extends HunterBaseEntity implements IAdvancedH
 
     @Override
     public @NotNull Optional<Holder<IVampireBook>> getBookLootId() {
-        return getData(ModAttachments.SUPPORTER).bookId();
+        return getData(ModAttachments.SUPPORTER).book();
     }
 
     @Nullable

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/hunter/AdvancedHunterEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/hunter/AdvancedHunterEntity.java
@@ -8,6 +8,7 @@ import de.teamlapen.vampirism.api.world.entity.VampireBookLootProvider;
 import de.teamlapen.vampirism.api.world.entity.hunter.IAdvancedHunter;
 import de.teamlapen.vampirism.api.world.entity.hunter.IVampirismCrossbowUser;
 import de.teamlapen.vampirism.api.world.items.IHunterCrossbow;
+import de.teamlapen.vampirism.api.world.items.components.IVampireBook;
 import de.teamlapen.vampirism.common.config.BalanceMobProps;
 import de.teamlapen.vampirism.common.core.ModAttachments;
 import de.teamlapen.vampirism.common.core.ModEntities;
@@ -116,7 +117,7 @@ public class AdvancedHunterEntity extends HunterBaseEntity implements IAdvancedH
     }
 
     @Override
-    public @NotNull Optional<String> getBookLootId() {
+    public @NotNull Optional<Holder<IVampireBook>> getBookLootId() {
         return getData(ModAttachments.SUPPORTER).bookId();
     }
 

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/vampire/AdvancedVampireEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/vampire/AdvancedVampireEntity.java
@@ -7,6 +7,7 @@ import de.teamlapen.vampirism.VampirismMod;
 import de.teamlapen.vampirism.api.difficulty.Difficulty;
 import de.teamlapen.vampirism.api.world.entity.VampireBookLootProvider;
 import de.teamlapen.vampirism.api.world.entity.vampire.IAdvancedVampire;
+import de.teamlapen.vampirism.api.world.items.components.IVampireBook;
 import de.teamlapen.vampirism.common.config.BalanceMobProps;
 import de.teamlapen.vampirism.common.core.ModAttachments;
 import de.teamlapen.vampirism.common.core.ModEffects;
@@ -16,7 +17,9 @@ import de.teamlapen.vampirism.common.util.supporter.Supporter;
 import de.teamlapen.vampirism.common.world.entity.ISupporterAppearanceConsumer;
 import de.teamlapen.vampirism.common.world.entity.ai.goals.*;
 import de.teamlapen.vampirism.common.world.entity.hunter.HunterBaseEntity;
+import net.minecraft.client.player.inventory.Hotbar;
 import net.minecraft.client.renderer.PlayerSkinRenderCache;
+import net.minecraft.core.Holder;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
@@ -109,7 +112,7 @@ public class AdvancedVampireEntity extends VampireBaseEntity implements IAdvance
     }
 
     @Override
-    public Optional<String> getBookLootId() {
+    public Optional<Holder<IVampireBook>> getBookLootId() {
         return getData(ModAttachments.SUPPORTER).bookId();
     }
 

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/vampire/AdvancedVampireEntity.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/common/world/entity/vampire/AdvancedVampireEntity.java
@@ -13,12 +13,9 @@ import de.teamlapen.vampirism.common.core.ModAttachments;
 import de.teamlapen.vampirism.common.core.ModEffects;
 import de.teamlapen.vampirism.common.core.ModEntities;
 import de.teamlapen.vampirism.common.util.UtilLib;
-import de.teamlapen.vampirism.common.util.supporter.Supporter;
 import de.teamlapen.vampirism.common.world.entity.ISupporterAppearanceConsumer;
 import de.teamlapen.vampirism.common.world.entity.ai.goals.*;
 import de.teamlapen.vampirism.common.world.entity.hunter.HunterBaseEntity;
-import net.minecraft.client.player.inventory.Hotbar;
-import net.minecraft.client.renderer.PlayerSkinRenderCache;
 import net.minecraft.core.Holder;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
@@ -48,7 +45,6 @@ import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -113,7 +109,7 @@ public class AdvancedVampireEntity extends VampireBaseEntity implements IAdvance
 
     @Override
     public Optional<Holder<IVampireBook>> getBookLootId() {
-        return getData(ModAttachments.SUPPORTER).bookId();
+        return getData(ModAttachments.SUPPORTER).book();
     }
 
     @Nullable

--- a/projects/vampirism/src/main/java/de/teamlapen/vampirism/data/loot/functions/SetVampireBookFunction.java
+++ b/projects/vampirism/src/main/java/de/teamlapen/vampirism/data/loot/functions/SetVampireBookFunction.java
@@ -60,20 +60,12 @@ public class SetVampireBookFunction extends LootItemConditionalFunction {
 
     @Override
     protected @NotNull ItemStack run(@NotNull ItemStack stack, @NotNull LootContext lootContext) {
-        RegistryAccess registryAccess = lootContext.getLevel().registryAccess();
         IVampireBook vampireBook = VampireBook.getRandomBook(tag, lootContext);
 
         Entity entity = lootContext.getOptionalParameter(LootContextParams.THIS_ENTITY);
         if (entity instanceof VampireBookLootProvider provider) {
             if (provider.getBookLootId().isPresent()) {
-                Identifier id = Identifier.parse(provider.getBookLootId().get());
-                Optional<IVampireBook> possibleBook = registryAccess.lookupOrThrow(VampirismRegistries.Keys.VAMPIRE_BOOK).getOptional(id);
-
-                if (possibleBook.isPresent()) {
-                    vampireBook = possibleBook.get();
-                } else {
-                    LOGGER.warn("Vampire Book \"{}\" does not exist, cannot add it to a loot table", id.getPath());
-                }
+                vampireBook = provider.getBookLootId().get().value();
             } else {
                 var tag = IFactionSpecificTags.get().get(IFactionHelper.get().getFaction(entity), VampirismRegistries.Keys.VAMPIRE_BOOK).orElse(ModVampireBookTags.IS_GENERAL);
                 vampireBook = VampireBook.getRandomBook(tag, lootContext);

--- a/projects/vampirism/src/main/resources/supporters.json
+++ b/projects/vampirism/src/main/resources/supporters.json
@@ -66,6 +66,7 @@
     "name": "Pyromaniac Pik",
     "status": "Contributor",
     "bookId": "piklach",
+    "book": "vampirism:pyromaniacs_diary",
     "appearance": {
       "hat": "hat_0",
       "main_hand": "vampirism:stake",
@@ -107,6 +108,7 @@
     "name": "Sinister Solace",
     "status": "Contributor",
     "bookId": "s_olace",
+    "book": "vampirism:sinister_intentions",
     "appearance": {
       "eye": "15",
       "type": "15",
@@ -193,6 +195,7 @@
     "name": "Valorous Vol",
     "status": "Temporary",
     "bookId": "volqonah",
+    "book": "vampirism:valorous_tale",
     "appearance": {
       "eye": "15",
       "type": "15",

--- a/projects/vampirism/src/main/resources/supporters.json
+++ b/projects/vampirism/src/main/resources/supporters.json
@@ -219,8 +219,8 @@
     "playerId": "052ef844-4947-452c-867d-902c8fa1cd94",
     "player": "gridexpert",
     "faction": "vampirism:hunter",
-    "name": "Dual-Wielding Grid",
-    "status": "Contributor",
+    "name": "Marcus Grid",
+    "status": "Dev",
     "appearance": {
       "hat": "hat_1",
       "hasCloak": "true",

--- a/schemas/supporters.schema.json
+++ b/schemas/supporters.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/TeamLapen/Vampirism/refs/heads/dev/schemas/supporters.schema.json",
+  "title": "Vampirism Supporters",
+  "description": "List of Vampirism supporters/contributors and the in-game appearance/faction assigned to them. Loaded by SupporterManager (faction, name, player, appearance, book); playerId/status/bookId are not read by the mod itself and only exist for the external supporters website.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["playerId", "player", "faction", "name", "status", "appearance"],
+    "properties": {
+      "playerId": {
+        "type": "string",
+        "description": "Minecraft account UUID of the supporter. Not read by the mod; In case the username changes the id stays the same",
+
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+      },
+      "player": {
+        "type": "string",
+        "description": "Minecraft username, used to resolve the player's skin at runtime.",
+        "minLength": 1
+      },
+      "faction": {
+        "type": "string",
+        "description": "Faction the supporter's in-game entity belongs to. Only vampirism:hunter and vampirism:vampire are recognized by SupporterManager's lookups.",
+        "enum": ["vampirism:hunter", "vampirism:vampire"]
+      },
+      "name": {
+        "type": "string",
+        "description": "Display name shown in-game for this supporter's entity.",
+        "minLength": 1
+      },
+      "status": {
+        "type": "string",
+        "description": "Supporter category, used by the external supporters website. Not validated/consumed by the mod.",
+        "enum": ["Contributor", "Dev", "Temporary"]
+      },
+      "bookId": {
+        "type": ["string", "null"],
+        "description": "Legacy id. Identifier used by the external supporters website to link this supporter to their book. Not read by the mod."
+      },
+      "book": {
+        "type": "string",
+        "description": "Registered vampire book id (VampirismRegistries VAMPIRE_BOOK) granted to this supporter, e.g. vampirism:pyromaniacs_diary.",
+        "pattern": "^[a-z0-9_.-]+:[a-z0-9_./-]+$"
+      },
+      "appearance": {
+        "type": "object",
+        "description": "Free-form string map describing the supporter entity's appearance. Only main_hand/off_hand/head/eyes are currently read by the renderer; other keys (hat, type, body, eye, hasCloak, equipment) are legacy/website-only and unused by the mod.",
+        "properties": {
+          "hat": {
+            "type": "string",
+            "description": "Legacy. Hunter hat overlay variant. Not currently read by the mod.",
+            "enum": ["none", "hat_0", "hat_1"]
+          },
+          "head": {
+            "type": "string",
+            "description": "Item id equipped in the head slot, e.g. vampirism:hunter_hat_broad.",
+            "pattern": "^[a-z0-9_.-]+:[a-z0-9_./-]+$"
+          },
+          "main_hand": {
+            "type": "string",
+            "description": "Item id held in the main hand, e.g. vampirism:hunter_axe_normal.",
+            "pattern": "^[a-z0-9_.-]+:[a-z0-9_./-]+$"
+          },
+          "off_hand": {
+            "type": "string",
+            "description": "Item id held in the off hand.",
+            "pattern": "^[a-z0-9_.-]+:[a-z0-9_./-]+$"
+          },
+          "equipment": {
+            "type": "string",
+            "description": "Legacy equipment variant tag (e.g. axe, axe_stake, crossbow, double_axe). Not currently read by the mod."
+          },
+          "type": {
+            "type": "string",
+            "description": "Legacy. Body/skin variant index. Not currently read by the mod.",
+            "pattern": "^[0-9]+$"
+          },
+          "body": {
+            "type": "string",
+            "description": "Legacy. Body texture variant index. Not currently read by the mod.",
+            "pattern": "^[0-9]+$"
+          },
+          "eye": {
+            "type": "string",
+            "description": "Legacy. Eye color variant index. Not currently read by the mod.",
+            "pattern": "^[0-9]+$"
+          },
+          "eyes": {
+            "type": "string",
+            "description": "Eye texture variant index, appended to 'eyes' to form the texture id (e.g. vampirism:eyes17).",
+            "pattern": "^[0-9]+$"
+          },
+          "hasCloak": {
+            "type": "string",
+            "description": "Legacy. Whether the vampire's cloak is rendered. Not currently read by the mod.",
+            "enum": ["true", "false"]
+          }
+        },
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/schemas/wings.schema.json
+++ b/schemas/wings.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/TeamLapen/Vampirism/refs/heads/dev/schemas/wings.schema.json",
+  "title": "Vampirism Wing Textures",
+  "description": "Assigns vampire wing textures to players. Loaded by WingsManager/WingsSetting (IWingsEntity.Texture enum + player UUID list). The same player id may legitimately appear under multiple texture blocks; each occurrence grants that texture in addition to the others.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["texture", "players"],
+    "additionalProperties": false,
+    "properties": {
+      "texture": {
+        "type": "string",
+        "description": "Wing texture variant, matched against the IWingsEntity.Texture enum (serialized as lowercase enum name). A value outside this set fails to parse and the whole entry is dropped with a warning.",
+        "enum": ["default", "dev", "castle_contest"]
+      },
+      "players": {
+        "type": "array",
+        "description": "Players granted this wing texture. May be empty.",
+        "items": {
+          "type": "object",
+          "required": ["name", "id"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Human-readable label only; not read anywhere else in the code, not used for matching.",
+              "minLength": 1
+            },
+            "id": {
+              "type": "string",
+              "description": "Minecraft account UUID. This is the only field used to match a player at runtime.",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Use IVampireBook registry deserializer for supporter to replace simple string id.

If the book is no longer available it will fallback to no book on deserialization.