### PR TITLE
Move trainer house and totem village additions to Lithostitched if installed

### DIFF
--- a/gradle/forge.gradle
+++ b/gradle/forge.gradle
@@ -60,6 +60,8 @@ dependencies {
     if (include_jade.toBoolean()) {
         runtimeOnly "curse.maven:jade-324717:" + project.jade_version
     }
+
+//    runtimeOnly "curse.maven:lithostitched-936015:8378498"
 }
 
 minecraft.accessTransformers.file rootProject.file('src/main/resources/META-INF/accesstransformer.cfg')

--- a/src/main/java/de/teamlapen/vampirism/world/gen/VanillaStructureModifications.java
+++ b/src/main/java/de/teamlapen/vampirism/world/gen/VanillaStructureModifications.java
@@ -16,6 +16,8 @@ import net.minecraft.world.level.levelgen.structure.pools.SinglePoolElement;
 import net.minecraft.world.level.levelgen.structure.pools.StructurePoolElement;
 import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
+import net.neoforged.fml.ModList;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -24,13 +26,19 @@ import java.util.function.Function;
 /**
  * Vanilla structures are modified in the following ways:
  * 1) Village structures are modified to include totem and hunter trainer house. Furthermore, some temples are replaced with custom versions. This is done during common setup.
- * 2) Explicitely specified structture pieces are limit to once per structure  via {@link de.teamlapen.vampirism.mixin.MixinJigsawPlacer}.
+ * 2) Explicitly specified structure pieces are limit to once per structure  via {@link de.teamlapen.vampirism.mixin.MixinJigsawPlacer}.
+ *
+ * If Lithostitched is installed, some of this is done using Litostitched and data files instead (`resources/data/vampirism/lithostitched`)
  */
 public class VanillaStructureModifications {
 
     public static void addVillageStructures(@NotNull RegistryAccess dynamicRegistries) {
-        addHunterTrainerHouse(dynamicRegistries, getDefaultPools());
-        addTotem(dynamicRegistries, getDefaultPools());
+        if (ModList.get().isLoaded("lithostitched")) {
+            LogManager.getLogger().info("Lithostitched is loaded, skipping manual totem/hunter trainer addition");
+        } else {
+            addHunterTrainerHouse(dynamicRegistries, getDefaultPools());
+            addTotem(dynamicRegistries, getDefaultPools());
+        }
         replaceTemples(dynamicRegistries, getTempleReplacements(dynamicRegistries.lookupOrThrow(Registries.PROCESSOR_LIST)));
     }
 
@@ -62,7 +70,7 @@ public class VanillaStructureModifications {
     }
 
     /**
-     * replaces half of the temples with temples with church altar
+     * replaces half of the temples with church altar
      */
     private static void replaceTemples(@NotNull RegistryAccess dynamicRegistries, @NotNull Map<ResourceLocation, Map<String, StructurePoolElement>> patternReplacements) {
         // return if temples should not be modified

--- a/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_totem.json
+++ b/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_totem.json
@@ -1,0 +1,25 @@
+{
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": [
+    "minecraft:village/plains/houses",
+    "minecraft:village/desert/houses",
+    "minecraft:village/savanna/houses",
+    "minecraft:village/taiga/houses",
+    "minecraft:village/snowy/houses"
+  ],
+  "elements": [
+    {
+      "weight": 20,
+      "element": {
+        "element_type": "lithostitched:limited",
+        "delegate": {
+          "element_type": "minecraft:single_pool_element",
+          "projection": "terrain_matching",
+          "location": "vampirism:village/totem",
+          "processors": "vampirism:totem_faction"
+        },
+        "limit": 1
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/desert.json
+++ b/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/desert.json
@@ -1,0 +1,21 @@
+{
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": [
+    "minecraft:village/desert/houses"
+  ],
+  "elements": [
+    {
+      "weight": 50,
+      "element": {
+        "element_type": "lithostitched:limited",
+        "delegate": {
+          "element_type": "minecraft:single_pool_element",
+          "projection": "rigid",
+          "location": "vampirism:village/desert/houses/hunter_trainer",
+          "processors": "minecraft:empty"
+        },
+        "limit": 1
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/plains.json
+++ b/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/plains.json
@@ -1,0 +1,21 @@
+{
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": [
+    "minecraft:village/plains/houses"
+  ],
+  "elements": [
+    {
+      "weight": 50,
+      "element": {
+        "element_type": "lithostitched:limited",
+        "delegate": {
+          "element_type": "minecraft:single_pool_element",
+          "projection": "rigid",
+          "location": "vampirism:village/plains/houses/hunter_trainer",
+          "processors": "minecraft:empty"
+        },
+        "limit": 1
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/savanna.json
+++ b/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/savanna.json
@@ -1,0 +1,21 @@
+{
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": [
+    "minecraft:village/savanna/houses"
+  ],
+  "elements": [
+    {
+      "weight": 50,
+      "element": {
+        "element_type": "lithostitched:limited",
+        "delegate": {
+          "element_type": "minecraft:single_pool_element",
+          "projection": "rigid",
+          "location": "vampirism:village/savanna/houses/hunter_trainer",
+          "processors": "minecraft:empty"
+        },
+        "limit": 1
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/snowy.json
+++ b/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/snowy.json
@@ -1,0 +1,21 @@
+{
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": [
+    "minecraft:village/snowy/houses"
+  ],
+  "elements": [
+    {
+      "weight": 50,
+      "element": {
+        "element_type": "lithostitched:limited",
+        "delegate": {
+          "element_type": "minecraft:single_pool_element",
+          "projection": "rigid",
+          "location": "vampirism:village/snowy/houses/hunter_trainer",
+          "processors": "minecraft:empty"
+        },
+        "limit": 1
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/taiga.json
+++ b/src/main/resources/data/vampirism/lithostitched/worldgen_modifier/village_trainer_house/taiga.json
@@ -1,0 +1,21 @@
+{
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": [
+    "minecraft:village/taiga/houses"
+  ],
+  "elements": [
+    {
+      "weight": 50,
+      "element": {
+        "element_type": "lithostitched:limited",
+        "delegate": {
+          "element_type": "minecraft:single_pool_element",
+          "projection": "rigid",
+          "location": "vampirism:village/taiga/houses/hunter_trainer",
+          "processors": "minecraft:empty"
+        },
+        "limit": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Creating PR for visibility/tracking.
Closes #1612

Lithostitched reworks structure generation and a.o. enables easy addition of structures to villages, including guaranteeing a minimum number of occurrences or limiting them.
https://github.com/Apollounknowndev/lithostitched/wiki/Adding-Entries-to-Template-Pools

This exactly what we need for the village totem and the hunter trainer house.
We currently implement this by adding the structures in `VanillaStructureModifications` and adding a Mixin to `JigsawPlacement.Placer` to limit the occurrences of specified structures (`resources/data/vampirism/vampirism/single_jigsaw_pieces.json`) to one.

This works fine, but our Mixin is ignored when Lithostitched is installed.

With this PR, Vampirism now uses Lithostitched to do these additions (the JSON files are only loaded by Lithostitched).
This does mean that the configured totem/trainer weights are ignored if Lithostitched is installed, but I think this is ok.

I don't see any downsides.
I will also change for 1.20.
Not sure about Vampirism 2.0
